### PR TITLE
Push watched-state to Plex when synced-folder files are deleted (Closes #7)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -12,7 +12,7 @@ from litestar.exceptions import NotFoundException
 from pydantic import BaseModel
 
 from common.log_utils import get_logger
-from synclet import sync_ops
+from synclet import pending, sync_ops
 from synclet.plex import fetch_art_bytes, fetch_thumb_bytes
 from synclet.resolve import resolve_url
 from synclet.scan import scan_title_detail, title_detail_to_dict
@@ -48,6 +48,24 @@ class RemoveFilesRequest(BaseModel):
 
 class ResolveLinkRequest(BaseModel):
     url: str
+
+
+class PendingItemRef(BaseModel):
+    """One pending-deletion item the user is acting on.
+
+    season and episode are None for movies. The (sync_sub, folder) pair is
+    unique within SYNC_ROOT, so no library disambiguation is needed.
+    """
+
+    sync_sub: str
+    folder: str
+    season: int | None = None
+    episode: int | None = None
+
+
+class ResolvePendingRequest(BaseModel):
+    items: list[PendingItemRef]
+    action: str  # "confirm" | "reject"
 
 
 # ── Routes ────────────────────────────────────────────────────────────────────
@@ -216,12 +234,12 @@ async def api_synced() -> dict:
     from synclet.config import LIBRARIES
     from synclet.fs_helpers import iter_synced_titles
     from synclet.scan import clean_name, scan_title_detail
-    from synclet.sync_ops import _find_source_lib
+    from synclet.sync_ops import find_source_lib
     from synclet.watchstate import show_watch_map
 
     items: list[dict] = []
     for _sub_path, item in iter_synced_titles():
-        source_lib = _find_source_lib(item.name)
+        source_lib = find_source_lib(item.name)
 
         display = clean_name(item.name)
         total_bytes = 0
@@ -284,6 +302,40 @@ async def api_maint_remove(data: RemoveFilesRequest) -> dict:
     return sync_ops.remove_files(data.paths)
 
 
+@get("/api/maintenance/pending")
+async def api_maint_pending() -> dict:
+    """Synced items whose files were deleted since the last snapshot.
+
+    Returned as a grouped tree (one entry per show/movie, episodes nested
+    under seasons for shows). The frontend (MaintenanceView pending pane)
+    renders this directly.
+    """
+    return {"items": pending.grouped_pending()}
+
+
+@post("/api/maintenance/resolve")
+async def api_maint_resolve(data: ResolvePendingRequest) -> dict:
+    """Confirm or reject a batch of pending deletions.
+
+    Confirm scrobbles each item to Plex (best-effort, per-item) and drops it
+    from the snapshot. Reject just drops from the snapshot. Per-item results
+    let the UI flag scrobble failures without aborting the rest of the batch.
+    """
+    if data.action not in {"confirm", "reject"}:
+        return {"error": f"unknown action: {data.action}", "results": []}
+    keys = [
+        pending.SnapshotKey(
+            sync_sub=item.sync_sub,
+            folder=item.folder,
+            season=item.season,
+            episode=item.episode,
+        )
+        for item in data.items
+    ]
+    results = pending.resolve(keys, confirm=(data.action == "confirm"))
+    return {"results": [r.to_dict() for r in results]}
+
+
 @post("/api/resolve-link")
 async def api_resolve(data: ResolveLinkRequest) -> dict:
     return resolve_url(data.url)
@@ -311,6 +363,8 @@ app = Litestar(
         api_maint_watched,
         api_maint_hanging,
         api_maint_remove,
+        api_maint_pending,
+        api_maint_resolve,
         api_resolve,
         api_refresh,
     ],

--- a/backend/synclet/config.py
+++ b/backend/synclet/config.py
@@ -34,11 +34,31 @@ WATCHLIST_RSS = os.environ.get(
 
 # library folder under MEDIA_ROOT -> (sync-folder under SYNC_ROOT, content kind, plex section id, display label)
 LIBRARIES: dict[str, dict] = {
-    "tv":           {"sync_sub": "tv",      "kind": "show",    "plex_section": 2,  "label": "TV"},
-    "tv-4kUHD":     {"sync_sub": "tv",      "kind": "show",    "plex_section": 12, "label": "TV 4K"},
-    "movies":       {"sync_sub": "movies",  "kind": "movie",   "plex_section": 1,  "label": "Movies"},
-    "movies-4kUHD": {"sync_sub": "movies",  "kind": "movie",   "plex_section": 7,  "label": "Movies 4K"},
-    "YouTube":      {"sync_sub": "youtube", "kind": "youtube", "plex_section": 6,  "label": "YouTube"},
+    "tv": {"sync_sub": "tv", "kind": "show", "plex_section": 2, "label": "TV"},
+    "tv-4kUHD": {
+        "sync_sub": "tv",
+        "kind": "show",
+        "plex_section": 12,
+        "label": "TV 4K",
+    },
+    "movies": {
+        "sync_sub": "movies",
+        "kind": "movie",
+        "plex_section": 1,
+        "label": "Movies",
+    },
+    "movies-4kUHD": {
+        "sync_sub": "movies",
+        "kind": "movie",
+        "plex_section": 7,
+        "label": "Movies 4K",
+    },
+    "YouTube": {
+        "sync_sub": "youtube",
+        "kind": "youtube",
+        "plex_section": 6,
+        "label": "YouTube",
+    },
 }
 
 EXCLUDED_DIRS = {".Recycle.Bin", ".recycle", ".trash", ".stfolder", ".stversions"}
@@ -55,3 +75,10 @@ STATE_CACHE_TTL = int(os.environ.get("SYNCLET_STATE_TTL", "30"))
 # Where to cache Plex poster bytes. Lives under /app/data inside the backend
 # container; persistent across restarts via docker-compose bind mount.
 THUMB_CACHE = Path(os.environ.get("SYNCLET_THUMB_CACHE", "/app/data/.thumb-cache"))
+
+# Snapshot of what Synclet last knew was synced. Source of truth for the
+# deletion-driven watch-state write-back flow (see synclet.pending). Persists
+# across restarts via the same /app/data bind mount as THUMB_CACHE.
+SNAPSHOT_FILE = Path(
+    os.environ.get("SYNCLET_SNAPSHOT_FILE", "/app/data/snapshot.json"),
+)

--- a/backend/synclet/pending.py
+++ b/backend/synclet/pending.py
@@ -1,0 +1,469 @@
+"""Deletion-driven watch-state write-back.
+
+When a file disappears from SYNC_ROOT, we infer the user finished watching it
+(or chose not to) and surface a confirm/reject decision. The single source of
+truth is `snapshot.json`: the set of media items Synclet last knew were synced.
+
+Pending = snapshot - on-disk. Resolve (confirm or reject) removes the item from
+the snapshot; confirm additionally scrobbles the item to Plex via
+`synclet.plex.scrobble`.
+
+Bootstrap: if the snapshot file does not yet exist, it is initialised from the
+current on-disk state, so the first run produces zero pending items.
+
+The snapshot key is `(sync_sub, folder, season, episode)` for shows and
+YouTube, and `(sync_sub, folder)` for movies (season and episode are None).
+`sync_sub` plus `folder` is unique inside SYNC_ROOT. The source library is
+resolved lazily via sync_ops.find_source_lib when metadata is needed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import asdict, dataclass
+from operator import itemgetter
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from synclet.config import LIBRARIES, SNAPSHOT_FILE, SYNC_ROOT, VIDEO_EXTS
+from synclet.fs_helpers import iter_sync_subs
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from typing import Literal
+
+    # Wire contract with the frontend (see ResolveStatus in types.ts). A typo
+    # in any of these strings is a Python type error AND a TS type error,
+    # which is the layered guarantee we want.
+    ResolveStatusType = Literal["ok", "scrobble_failed", "no_rating_key", "rejected"]
+
+_EP_PAT = re.compile(r"[Ss](\d+)[Ee](\d+)", re.IGNORECASE)
+
+
+# ── Sync-sub kind map (derived from LIBRARIES, stable per process) ──────────
+
+
+def _sync_sub_kinds() -> dict[str, str]:
+    """{sync_sub: kind} derived from LIBRARIES.
+
+    DO NOT call from import time. LIBRARIES can be monkeypatched in tests, and
+    a module-level cache would freeze the test fixture's view. Cheap to rebuild
+    (5 entries today).
+    """
+    out: dict[str, str] = {}
+    for info in LIBRARIES.values():
+        out[info["sync_sub"]] = info["kind"]
+    return out
+
+
+# ── Snapshot key ────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class SnapshotKey:
+    """Identifies a synced media item.
+
+    For shows and youtube, season and episode are populated. For movies, both
+    are None and the (sync_sub, folder) pair fully identifies the item.
+    """
+
+    sync_sub: str
+    folder: str
+    season: int | None = None
+    episode: int | None = None
+
+    def to_dict(self) -> dict:
+        """JSON-serialisable dict form, matches the snapshot file schema."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, d: dict) -> SnapshotKey:
+        """Inverse of to_dict; tolerant of missing season/episode (movies)."""
+        return cls(
+            sync_sub=d["sync_sub"],
+            folder=d["folder"],
+            season=d.get("season"),
+            episode=d.get("episode"),
+        )
+
+
+# ── Path -> SnapshotKey ─────────────────────────────────────────────────────
+
+
+# Minimum SYNC_ROOT-relative path depth that can identify a media item: at
+# least <sync_sub>/<folder>/... — anything shallower is a stray top-level file.
+_MIN_REL_PARTS = 2
+
+
+def path_to_snapshot_key(path: Path) -> SnapshotKey | None:  # noqa: PLR0911 — guards
+    """Reverse a synced file path to its SnapshotKey.
+
+    Returns None for paths outside SYNC_ROOT, non-video files, or paths whose
+    sync_sub is not in the current LIBRARIES config (stale leftover sync sub
+    that we no longer manage).
+    """
+    if path.suffix.lower() not in VIDEO_EXTS:
+        return None
+    try:
+        rel = path.relative_to(SYNC_ROOT)
+    except ValueError:
+        return None
+    parts = rel.parts
+    if len(parts) < _MIN_REL_PARTS:
+        return None
+    sync_sub, folder = parts[0], parts[1]
+    kind = _sync_sub_kinds().get(sync_sub)
+    if kind is None:
+        return None
+    if kind == "movie":
+        return SnapshotKey(sync_sub=sync_sub, folder=folder)
+    # show / youtube: extract season+episode from the filename
+    match = _EP_PAT.search(path.name)
+    if not match:
+        return None
+    return SnapshotKey(
+        sync_sub=sync_sub,
+        folder=folder,
+        season=int(match.group(1)),
+        episode=int(match.group(2)),
+    )
+
+
+# ── On-disk scan ────────────────────────────────────────────────────────────
+
+
+def scan_on_disk() -> set[SnapshotKey]:
+    """Walk SYNC_ROOT and return the set of currently-present SnapshotKeys.
+
+    Non-video files (subtitles, sidecars) are ignored: the snapshot tracks
+    media items, not individual files. A show episode is "on disk" if any of
+    its video files exists.
+    """
+    out: set[SnapshotKey] = set()
+    for sub_path in iter_sync_subs():
+        for video in _iter_videos(sub_path):
+            key = path_to_snapshot_key(video)
+            if key is not None:
+                out.add(key)
+    return out
+
+
+def _iter_videos(root: Path) -> Iterable[Path]:
+    """Yield every video file under root, skipping dotfiles and hidden dirs.
+
+    Uses os.scandir for efficiency: SYNC_ROOT can have thousands of files
+    across a few hundred folders, and Path.rglob is roughly an order of
+    magnitude slower on shfs FUSE.
+    """
+    for entry in os.scandir(root):
+        name = entry.name
+        if name.startswith("."):
+            continue
+        try:
+            if entry.is_dir(follow_symlinks=False):
+                yield from _iter_videos(Path(entry.path))
+            elif entry.is_file(follow_symlinks=False) and (
+                Path(entry.path).suffix.lower() in VIDEO_EXTS
+            ):
+                yield Path(entry.path)
+        except OSError:
+            continue
+
+
+# ── Snapshot I/O ────────────────────────────────────────────────────────────
+
+
+def load_snapshot() -> set[SnapshotKey]:
+    """Return the persisted snapshot, or an empty set if the file is missing.
+
+    A missing file means "not bootstrapped yet" — callers should run
+    bootstrap_if_missing() before computing pending, otherwise every existing
+    on-disk file would erroneously appear as a deletion candidate the first
+    time the feature is used.
+    """
+    if not SNAPSHOT_FILE.exists():
+        return set()
+    try:
+        raw = json.loads(SNAPSHOT_FILE.read_text())
+    except (OSError, json.JSONDecodeError):
+        return set()
+    items = raw.get("items", [])
+    return {SnapshotKey.from_dict(item) for item in items if isinstance(item, dict)}
+
+
+def save_snapshot(keys: set[SnapshotKey]) -> None:
+    """Persist the snapshot atomically.
+
+    Writes to a sibling tempfile then renames, so a crashed write cannot
+    leave a half-written JSON file that load_snapshot would silently swallow.
+    """
+    SNAPSHOT_FILE.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": 1,
+        "items": sorted(
+            (k.to_dict() for k in keys),
+            key=lambda d: (
+                d["sync_sub"],
+                d["folder"],
+                d.get("season") or -1,
+                d.get("episode") or -1,
+            ),
+        ),
+    }
+    tmp = SNAPSHOT_FILE.with_suffix(SNAPSHOT_FILE.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2))
+    tmp.replace(SNAPSHOT_FILE)
+
+
+def bootstrap_if_missing() -> bool:
+    """If the snapshot file does not exist, write one matching current disk.
+
+    Returns True if bootstrap fired (cold-start state), False otherwise.
+    """
+    if SNAPSHOT_FILE.exists():
+        return False
+    save_snapshot(scan_on_disk())
+    return True
+
+
+# ── Snapshot mutation hooks ─────────────────────────────────────────────────
+
+
+def add_keys(keys: Iterable[SnapshotKey]) -> None:
+    """Add items to the snapshot. Called when a sync job completes."""
+    keys = set(keys)
+    if not keys:
+        return
+    bootstrap_if_missing()
+    current = load_snapshot()
+    save_snapshot(current | keys)
+
+
+def remove_keys(keys: Iterable[SnapshotKey]) -> None:
+    """Remove items from the snapshot.
+
+    Called for two implicit-confirm paths: the maintenance "remove watched"
+    flow (the user is removing precisely because they watched), and the
+    explicit resolve flow whether confirm or reject.
+    """
+    keys = set(keys)
+    if not keys:
+        return
+    current = load_snapshot()
+    new = current - keys
+    if new != current:
+        save_snapshot(new)
+
+
+def keys_for_paths(paths: Iterable[str | Path]) -> set[SnapshotKey]:
+    """Translate a batch of file paths into SnapshotKeys.
+
+    Non-video paths and paths outside SYNC_ROOT are silently dropped. Used by
+    sync_ops.remove_files to update the snapshot when files are deleted via
+    the maintenance UI.
+    """
+    out: set[SnapshotKey] = set()
+    for raw in paths:
+        key = path_to_snapshot_key(Path(raw))
+        if key is not None:
+            out.add(key)
+    return out
+
+
+# ── Pending computation ─────────────────────────────────────────────────────
+
+
+def compute_pending() -> set[SnapshotKey]:
+    """Return the set of SnapshotKeys present in the snapshot but not on disk."""
+    bootstrap_if_missing()
+    return load_snapshot() - scan_on_disk()
+
+
+# ── Grouping for the API response ───────────────────────────────────────────
+
+
+def grouped_pending() -> list[dict]:
+    """Return pending items grouped by show/movie, enriched with Plex metadata.
+
+    Shape (consumed by the frontend MaintenanceView pending pane):
+
+        [
+          {
+            "sync_sub": "tv", "folder": "Better Call Saul (2015)...",
+            "title": "Better Call Saul", "kind": "show",
+            "lib": "tv", "rating_key": "100" or null,
+            "seasons": [
+              {
+                "season": 1,
+                "episodes": [
+                  {"season": 1, "episode": 1,
+                   "already_watched_in_plex": false,
+                   "episode_rating_key": "1001" or null,
+                   "title": "Uno"}
+                ]
+              }
+            ]
+          },
+          {
+            "sync_sub": "movies", "folder": "1917 (2019)...",
+            "title": "1917", "kind": "movie",
+            "lib": "movies", "rating_key": "300" or null,
+            "already_watched_in_plex": false
+          }
+        ]
+
+    Plex enrichment is best-effort. If section_index() returns nothing (Plex
+    down, library re-scanning), rating_keys come back None and the UI shows
+    the entries with reject-only affordances; confirm will fail per-item
+    rather than the whole list failing to render.
+    """
+    # Local imports avoid cycles: plex -> scan -> ... and sync_ops needs us.
+    from synclet.plex import episode_rating_keys, find_in_library  # noqa: PLC0415
+    from synclet.scan import clean_name  # noqa: PLC0415
+    from synclet.sync_ops import find_source_lib  # noqa: PLC0415
+    from synclet.watchstate import movie_watch_state, show_watch_map  # noqa: PLC0415
+
+    by_folder: dict[tuple[str, str], list[SnapshotKey]] = {}
+    for key in compute_pending():
+        by_folder.setdefault((key.sync_sub, key.folder), []).append(key)
+
+    out: list[dict] = []
+    kinds = _sync_sub_kinds()
+    for (sync_sub, folder), keys in sorted(by_folder.items()):
+        kind = kinds.get(sync_sub, "show")
+        display = clean_name(folder)
+        lib = find_source_lib(folder)
+        meta = find_in_library(lib, folder) if lib else None
+        show_rk = meta["ratingKey"] if meta else None
+
+        if kind == "movie":
+            already_watched = bool(movie_watch_state(display))
+            out.append(
+                {
+                    "sync_sub": sync_sub,
+                    "folder": folder,
+                    "title": display,
+                    "kind": kind,
+                    "lib": lib,
+                    "rating_key": show_rk,
+                    "already_watched_in_plex": already_watched,
+                },
+            )
+            continue
+
+        # show / youtube
+        ws_map = show_watch_map(display)
+        ep_rk_map = episode_rating_keys(show_rk) if show_rk else {}
+
+        seasons: dict[int, list[dict]] = {}
+        for k in keys:
+            if k.season is None or k.episode is None:
+                continue
+            episode_entry = {
+                "season": k.season,
+                "episode": k.episode,
+                "already_watched_in_plex": bool(ws_map.get((k.season, k.episode))),
+                "episode_rating_key": ep_rk_map.get((k.season, k.episode)),
+                "title": "",
+            }
+            seasons.setdefault(k.season, []).append(episode_entry)
+
+        if not seasons:
+            # Hand-edited snapshot with show keys missing season/episode.
+            # Don't surface a malformed group; let the snapshot decay naturally.
+            continue
+
+        out.append(
+            {
+                "sync_sub": sync_sub,
+                "folder": folder,
+                "title": display,
+                "kind": kind,
+                "lib": lib,
+                "rating_key": show_rk,
+                "seasons": [
+                    {
+                        "season": s,
+                        "episodes": sorted(eps, key=itemgetter("episode")),
+                    }
+                    for s, eps in sorted(seasons.items())
+                ],
+            },
+        )
+    return out
+
+
+# ── Resolve orchestration ───────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ResolveResult:
+    """Per-item outcome of a resolve call.
+
+    `status` is the wire contract field consumed by MaintenanceView.vue
+    (see ResolveStatus in types.ts). Mirrored as a Literal alias above for
+    typo-safety: a misspelled status here is a Python type error.
+    """
+
+    key: SnapshotKey
+    status: ResolveStatusType
+
+    def to_dict(self) -> dict:
+        """JSON-serialisable dict: SnapshotKey fields plus status."""
+        d = self.key.to_dict()
+        d["status"] = self.status
+        return d
+
+
+def resolve(keys: Iterable[SnapshotKey], *, confirm: bool) -> list[ResolveResult]:
+    """Resolve a batch of pending keys.
+
+    On reject: every key is dropped from the snapshot, returns status
+    "rejected" per key. On confirm: each key is scrobbled to Plex first
+    (best-effort, per-item); successful scrobbles get status "ok", failures
+    get "scrobble_failed" or "no_rating_key". The snapshot drops every key
+    regardless of scrobble outcome — the user already deleted the file, so
+    putting it back in pending would be incorrect.
+    """
+    # Local imports keep the module's import graph small.
+    from synclet.plex import (  # noqa: PLC0415
+        episode_rating_keys,
+        find_in_library,
+        scrobble,
+    )
+    from synclet.sync_ops import find_source_lib  # noqa: PLC0415
+
+    keys = list(keys)
+    results: list[ResolveResult] = []
+
+    if not confirm:
+        results.extend(ResolveResult(key=k, status="rejected") for k in keys)
+        remove_keys(keys)
+        return results
+
+    for k in keys:
+        lib = find_source_lib(k.folder)
+        meta = find_in_library(lib, k.folder) if lib else None
+        show_rk = meta["ratingKey"] if meta else None
+        target_rk: str | None
+        if k.season is None or k.episode is None:
+            # Movie
+            target_rk = show_rk
+        elif show_rk:
+            target_rk = episode_rating_keys(show_rk).get((k.season, k.episode))
+        else:
+            target_rk = None
+
+        if target_rk is None:
+            results.append(ResolveResult(key=k, status="no_rating_key"))
+            continue
+
+        if scrobble(target_rk):
+            results.append(ResolveResult(key=k, status="ok"))
+        else:
+            results.append(ResolveResult(key=k, status="scrobble_failed"))
+
+    remove_keys(keys)
+    return results

--- a/backend/synclet/plex.py
+++ b/backend/synclet/plex.py
@@ -24,7 +24,9 @@ def _plex_url(path: str, params: dict | None = None) -> str:
     return f"{PLEX_URL}{path}?{urllib.parse.urlencode(qp)}"
 
 
-def _get_xml(path: str, params: dict | None = None, timeout: int = 8) -> ET.Element | None:
+def _get_xml(
+    path: str, params: dict | None = None, timeout: int = 8
+) -> ET.Element | None:
     try:
         with urllib.request.urlopen(_plex_url(path, params), timeout=timeout) as r:
             return ET.fromstring(r.read())
@@ -40,7 +42,7 @@ def section_index(section_id: int) -> dict[str, dict]:
     (show) entries, so we can't join by folder path. Instead we join by the
     same key WatchState uses: title with year/tvdb cruft stripped, lowercased.
     """
-    from synclet.scan import watchstate_key   # local to avoid cycle
+    from synclet.scan import watchstate_key  # local to avoid cycle
 
     root = _get_xml(f"/library/sections/{section_id}/all", timeout=30)
     if root is None:
@@ -118,6 +120,56 @@ def fetch_art_bytes(lib: str, folder: str) -> tuple[bytes, str] | None:
         return data, content_type
     except Exception:
         return None
+
+
+# ── Write-back: episode ratingKey lookup + scrobble ─────────────────────────
+
+
+@lru_cache(maxsize=64)
+def episode_rating_keys(show_rating_key: str) -> dict[tuple[int, int], str]:
+    """Return {(season_index, episode_index): episode_rating_key} for a show.
+
+    Scrobble takes the EPISODE's ratingKey, not the show's. Plex exposes
+    `/library/metadata/{showRatingKey}/allLeaves` as a flat list of every
+    episode in one round-trip. Cached for the process lifetime since Plex
+    episode ratingKeys are stable.
+    """
+    root = _get_xml(f"/library/metadata/{show_rating_key}/allLeaves", timeout=15)
+    if root is None:
+        return {}
+    out: dict[tuple[int, int], str] = {}
+    for video in root:
+        if video.tag != "Video":
+            continue
+        rk = video.get("ratingKey")
+        s = video.get("parentIndex")
+        e = video.get("index")
+        if rk and s is not None and e is not None:
+            try:
+                out[(int(s), int(e))] = rk
+            except ValueError:
+                continue
+    return out
+
+
+def scrobble(rating_key: str, timeout: int = 8) -> bool:
+    """Mark a Plex item watched. Returns True on success.
+
+    `PUT /:/scrobble?identifier=com.plexapp.plugins.library&key=<ratingKey>`
+    is idempotent. Plex returns 200 even if the item was already watched, so
+    callers don't need to pre-check. Network errors and non-2xx responses
+    return False so callers can report per-item status without aborting a
+    batch resolve.
+    """
+    url = _plex_url(
+        "/:/scrobble",
+        {"identifier": "com.plexapp.plugins.library", "key": rating_key},
+    )
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as r:  # noqa: S310
+            return 200 <= r.status < 300
+    except Exception:  # noqa: BLE001
+        return False
 
 
 def get_metadata(rating_key: str) -> dict | None:

--- a/backend/synclet/resolve.py
+++ b/backend/synclet/resolve.py
@@ -102,7 +102,11 @@ def resolve_url(url: str) -> dict:
                 by = _by_name(title)
                 if by:
                     return {"found": True, **by, "via": "plex_metadata"}
-        return {"found": False, "reason": "plex_metadata_lookup_failed", "ratingKey": rk}
+        return {
+            "found": False,
+            "reason": "plex_metadata_lookup_failed",
+            "ratingKey": rk,
+        }
 
     # 2. IMDb URL — fall back to title parsing from URL path (best-effort)
     m = _IMDB.search(decoded)
@@ -113,7 +117,11 @@ def resolve_url(url: str) -> dict:
     # 3. Jellyfin item URL — id is a server-local guid, can't resolve from outside
     m = _JELLYFIN_ID.search(decoded)
     if m:
-        return {"found": False, "reason": "jellyfin_url_unsupported", "jellyfin_id": m.group(1)}
+        return {
+            "found": False,
+            "reason": "jellyfin_url_unsupported",
+            "jellyfin_id": m.group(1),
+        }
 
     # 4. Plain text — fuzzy search the library
     by = _by_name(decoded)

--- a/backend/synclet/scan.py
+++ b/backend/synclet/scan.py
@@ -37,15 +37,15 @@ _EP_TITLE_FROM_FILENAME = re.compile(
 class Title:
     """A show, movie, or YouTube channel as seen from disk."""
 
-    id: str                          # f"{lib}/{folder}" — stable composite key
+    id: str  # f"{lib}/{folder}" — stable composite key
     lib: str
-    folder: str                      # raw folder name (with {tvdb-...} cruft)
-    name: str                        # display name (cleaned)
-    kind: str                        # "show" | "movie" | "youtube"
+    folder: str  # raw folder name (with {tvdb-...} cruft)
+    name: str  # display name (cleaned)
+    kind: str  # "show" | "movie" | "youtube"
     year: int | None
-    ep_count: int                    # 0 for movies; episode count for shows
-    synced_files: int                # count of files present in synced-media for this title
-    has_synced: bool                 # convenience: synced_files > 0
+    ep_count: int  # 0 for movies; episode count for shows
+    synced_files: int  # count of files present in synced-media for this title
+    has_synced: bool  # convenience: synced_files > 0
 
     def to_dict(self) -> dict:
         return {
@@ -67,9 +67,9 @@ class Episode:
     episode: int
     title: str
     size_bytes: int
-    files: list[str] = field(default_factory=list)   # absolute paths
+    files: list[str] = field(default_factory=list)  # absolute paths
     is_synced: bool = False
-    watch_state: str = "unwatched"   # "unwatched" | "watched" | "progress"
+    watch_state: str = "unwatched"  # "unwatched" | "watched" | "progress"
     watch_pct: int = 0
 
 
@@ -129,7 +129,8 @@ def is_wanted_file(f: Path) -> bool:
     qualifiers = f.stem.lower().split(".")
     lang = next(
         (
-            q for q in reversed(qualifiers)
+            q
+            for q in reversed(qualifiers)
             if re.fullmatch(r"[a-z]{2,3}", q) and q not in SUBTITLE_QUALIFIERS
         ),
         None,
@@ -170,7 +171,9 @@ def _synced_folder_index() -> dict[str, int]:
     for sub_path in iter_sync_subs():
         with os.scandir(sub_path) as it:
             for entry in it:
-                if not entry.is_dir(follow_symlinks=False) or entry.name.startswith("."):
+                if not entry.is_dir(follow_symlinks=False) or entry.name.startswith(
+                    "."
+                ):
                     continue
                 # rglob over a single synced title — small (one show's worth).
                 n = 0
@@ -194,7 +197,7 @@ def scan_titles() -> list[Title]:
     """
     from synclet.watchstate import all_watched_shows  # local to avoid cycle
 
-    show_eps = all_watched_shows()                         # {show_title_lower: {(s,e): watched}}
+    show_eps = all_watched_shows()  # {show_title_lower: {(s,e): watched}}
     show_ep_count = {k: len(v) for k, v in show_eps.items()}
     synced_index = _synced_folder_index()
 
@@ -205,17 +208,22 @@ def scan_titles() -> list[Title]:
             continue
         with os.scandir(root) as it:
             entries = sorted(
-                (e for e in it
-                 if e.is_dir(follow_symlinks=False)
-                 and e.name not in EXCLUDED_DIRS
-                 and not e.name.startswith(".")),
+                (
+                    e
+                    for e in it
+                    if e.is_dir(follow_symlinks=False)
+                    and e.name not in EXCLUDED_DIRS
+                    and not e.name.startswith(".")
+                ),
                 key=lambda e: e.name,
             )
         for entry in entries:
             kind = info["kind"]
             name = clean_name(entry.name)
             ws_key = watchstate_key(entry.name)
-            ep_count = show_ep_count.get(ws_key, 0) if kind in ("show", "youtube") else 0
+            ep_count = (
+                show_ep_count.get(ws_key, 0) if kind in ("show", "youtube") else 0
+            )
             synced_files = synced_index.get(entry.name, 0)
 
             out.append(
@@ -243,7 +251,8 @@ def _files_for_episode(season_dir: Path, s_num: int, e_num: int) -> list[Path]:
         re.compile(rf"[Ss]{s_num}[Ee]{e_num:04d}(?!\d)", re.IGNORECASE),
     ]
     return sorted(
-        f for f in season_dir.iterdir()
+        f
+        for f in season_dir.iterdir()
         if not f.is_dir() and any(p.search(f.name) for p in pats)
     )
 
@@ -277,7 +286,9 @@ def scan_title_detail(lib: str, folder: str) -> TitleDetail | None:
     )
 
     if info["kind"] == "movie":
-        files = sorted(f for f in path.iterdir() if not f.is_dir() and is_wanted_file(f))
+        files = sorted(
+            f for f in path.iterdir() if not f.is_dir() and is_wanted_file(f)
+        )
         total = 0
         synced = 0
         for f in files:
@@ -320,7 +331,9 @@ def scan_title_detail(lib: str, folder: str) -> TitleDetail | None:
             wanted = [f for f in files if is_wanted_file(f)]
             videos = [f for f in wanted if f.suffix.lower() in VIDEO_EXTS]
             size = sum(f.stat().st_size for f in wanted)
-            is_synced = bool(videos) and all(_sync_dest(v, lib).exists() for v in videos)
+            is_synced = bool(videos) and all(
+                _sync_dest(v, lib).exists() for v in videos
+            )
             ep = Episode(
                 season=s_num,
                 episode=e_num,

--- a/backend/synclet/state.py
+++ b/backend/synclet/state.py
@@ -49,7 +49,9 @@ def _build() -> list[TitleWithState]:
             watched = sum(1 for v in ws_map.values() if v)
             denom = max(t.ep_count, 1)
             watched_pct = min(100, int(watched / denom * 100)) if t.ep_count else 0
-            synced_pct = min(100, int(t.synced_files / denom * 100)) if t.ep_count else 0
+            synced_pct = (
+                min(100, int(t.synced_files / denom * 100)) if t.ep_count else 0
+            )
         else:
             watched = 1 if movies.get(ws_key) else 0
             watched_pct = 100 if watched else 0

--- a/backend/synclet/sync_ops.py
+++ b/backend/synclet/sync_ops.py
@@ -20,16 +20,17 @@ from pathlib import PurePath
 from synclet.config import LIBRARIES, MEDIA_ROOT, SYNC_ROOT, VIDEO_EXTS
 from synclet.fs_helpers import iter_sync_subs, iter_synced_titles
 from synclet.scan import is_wanted_file, scan_title_detail
+from synclet import pending as pending_mod
 from synclet import state as state_mod
 
 
 @dataclass
 class Job:
     id: str
-    op: str                                # "sync" | "unsync"
-    status: str                            # "queued" | "running" | "done" | "error"
-    total_files: int = 0                   # every file (videos + subs + chapters)
-    total_media_files: int = 0             # video files only — what humans care about
+    op: str  # "sync" | "unsync"
+    status: str  # "queued" | "running" | "done" | "error"
+    total_files: int = 0  # every file (videos + subs + chapters)
+    total_media_files: int = 0  # video files only — what humans care about
     processed_files: int = 0
     processed_media_files: int = 0
     processed_bytes: int = 0
@@ -38,7 +39,7 @@ class Job:
     started_at: float = 0.0
     ended_at: float = 0.0
     error: str = ""
-    title: str = ""                        # display name for the job
+    title: str = ""  # display name for the job
     items: list[dict] = field(default_factory=list)  # [{src, dst, size, is_video}]
 
     def to_dict(self) -> dict:
@@ -110,9 +111,10 @@ def resolve_selection(
     lib: str,
     folder: str,
     *,
-    selection_type: str,                     # "all" | "season" | "episodes" | "movie"
+    selection_type: str,  # "all" | "season" | "episodes" | "movie"
     season: int | None = None,
-    episodes: list[list[int]] | None = None, # [[s,e], ...] for selection_type="episodes"
+    episodes: list[list[int]]
+    | None = None,  # [[s,e], ...] for selection_type="episodes"
     unwatched_only: bool = False,
 ) -> list[tuple[Path, Path]]:
     """Return [(src, dst)] pairs given the user's selection.
@@ -124,12 +126,15 @@ def resolve_selection(
         return []
 
     if detail.kind == "movie":
-        files = [Path(f["path"]) for f in detail.files if is_wanted_file(Path(f["path"]))]
+        files = [
+            Path(f["path"]) for f in detail.files if is_wanted_file(Path(f["path"]))
+        ]
         return [(f, _sync_dest(f, lib)) for f in files]
 
     watched_map: dict[tuple[int, int], bool] | None = None
     if unwatched_only:
         from synclet.watchstate import show_watch_map
+
         watched_map = show_watch_map(detail.name)
 
     ep_keys: list[tuple[int, int]] | None = None
@@ -170,6 +175,15 @@ async def _run_sync(job: Job) -> None:
                 job.processed_media_files += 1
             job.processed_bytes += item["size"]
         job.status = "done"
+        # Snapshot tracks what Synclet thinks is on disk. A completed sync
+        # adds every newly-present media file. Run after the loop, not per
+        # item, so a mid-job crash doesn't half-update the snapshot.
+        added_keys = {
+            pending_mod.path_to_snapshot_key(Path(item["dst"]))
+            for item in job.items
+            if item["is_video"]
+        }
+        pending_mod.add_keys(k for k in added_keys if k is not None)
     except Exception as exc:  # noqa: BLE001 — surface to client verbatim
         job.error = str(exc)
         job.status = "error"
@@ -202,6 +216,14 @@ async def _run_unsync(job: Job) -> None:
             except OSError:
                 pass
         job.status = "done"
+        # Explicit unsync is "I no longer want this here", not "I watched it".
+        # Same shape as a reject: drop from snapshot, do not scrobble.
+        unsync_keys = {
+            pending_mod.path_to_snapshot_key(Path(item["dst"]))
+            for item in job.items
+            if item["is_video"]
+        }
+        pending_mod.remove_keys(k for k in unsync_keys if k is not None)
     except Exception as exc:  # noqa: BLE001
         job.error = str(exc)
         job.status = "error"
@@ -221,7 +243,12 @@ def start_sync(pairs: list[tuple[Path, Path]], title: str = "") -> Job:
         except OSError:
             continue
         items.append(
-            {"src": str(src), "dst": str(dst), "size": size, "is_video": _is_video(str(src))}
+            {
+                "src": str(src),
+                "dst": str(dst),
+                "size": size,
+                "is_video": _is_video(str(src)),
+            }
         )
     job.items = items
     job.total_files = len(items)
@@ -242,7 +269,12 @@ def start_unsync(pairs: list[tuple[Path, Path]], title: str = "") -> Job:
             except OSError:
                 size = 0
             items.append(
-                {"src": str(src), "dst": str(dst), "size": size, "is_video": _is_video(str(dst))}
+                {
+                    "src": str(src),
+                    "dst": str(dst),
+                    "size": size,
+                    "is_video": _is_video(str(dst)),
+                }
             )
     job.items = items
     job.total_files = len(items)
@@ -256,7 +288,7 @@ def start_unsync(pairs: list[tuple[Path, Path]], title: str = "") -> Job:
 # ── Maintenance: remove watched, hanging files ────────────────────────────────
 
 
-def _find_source_lib(folder_name: str) -> str | None:
+def find_source_lib(folder_name: str) -> str | None:
     """Return the library name whose media folder contains `folder_name`."""
     for lib in LIBRARIES:
         if (MEDIA_ROOT / lib / folder_name).exists():
@@ -274,7 +306,7 @@ def find_watched_synced_files() -> list[dict]:
 
     out: list[dict] = []
     for _sub_path, item in iter_synced_titles():
-        source_lib = _find_source_lib(item.name)
+        source_lib = find_source_lib(item.name)
         if not source_lib:
             continue
 
@@ -328,7 +360,11 @@ def find_hanging_files() -> list[dict]:
         for dirpath in sub_path.rglob("*"):
             if not dirpath.is_dir() or dirpath.name.startswith("."):
                 continue
-            files = [f for f in dirpath.iterdir() if f.is_file() and not f.name.startswith(".")]
+            files = [
+                f
+                for f in dirpath.iterdir()
+                if f.is_file() and not f.name.startswith(".")
+            ]
             if not files:
                 continue
             if not any(f.suffix.lower() in VIDEO_EXTS for f in files):
@@ -344,6 +380,12 @@ def find_hanging_files() -> list[dict]:
 
 
 def remove_files(paths: list[str]) -> dict:
+    # Translate to snapshot keys BEFORE deleting; path_to_snapshot_key reads
+    # the file extension, not the inode, so post-delete translation still
+    # works, but doing it first means the resolution is unambiguous even if
+    # a sibling path collision happens.
+    keys_removing = pending_mod.keys_for_paths(paths)
+
     removed = 0
     bytes_freed = 0
     parents: set[Path] = set()
@@ -366,4 +408,8 @@ def remove_files(paths: list[str]) -> dict:
         except OSError:
             pass
     state_mod.invalidate()
+    # Implicit confirm: the maintenance "remove watched" path means the user
+    # already watched these in Plex. Drop them from the snapshot so they do
+    # NOT later appear as pending deletions.
+    pending_mod.remove_keys(keys_removing)
     return {"removed": removed, "bytes_freed": bytes_freed}

--- a/backend/synclet/watchlist.py
+++ b/backend/synclet/watchlist.py
@@ -42,7 +42,10 @@ def get_watchlist() -> list[dict]:
     out: list[dict] = []
     for item in items:
         scored = sorted(
-            ((fuzzy_score(item["title"], n), n, lib, folder, ts) for n, lib, folder, ts in titles),
+            (
+                (fuzzy_score(item["title"], n), n, lib, folder, ts)
+                for n, lib, folder, ts in titles
+            ),
             key=lambda x: -x[0],
         )
         best = scored[0] if scored else None

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -48,9 +48,9 @@ def watchstate_db(tmp_path: Path) -> Path:
         ("episode", 0, 1, "plex", "Better Call Saul", 2015, 1, 1),
         ("episode", 0, 1, "plex", "Better Call Saul", 2015, 1, 2),
         ("episode", 0, 0, "plex", "Better Call Saul", 2015, 1, 3),
-        ("episode", 0, 1, "plex", "After Life",       2019, 1, 1),
-        ("movie",   0, 1, "plex", "The Boys",         2019, None, None),
-        ("movie",   0, 0, "plex", "1917",             2019, None, None),
+        ("episode", 0, 1, "plex", "After Life", 2019, 1, 1),
+        ("movie", 0, 1, "plex", "The Boys", 2019, None, None),
+        ("movie", 0, 0, "plex", "1917", 2019, None, None),
     ]
     conn.executemany(
         "INSERT INTO state (type, updated, watched, via, title, year, season, episode)"
@@ -75,6 +75,7 @@ def patch_watchstate(monkeypatch: pytest.MonkeyPatch, watchstate_db: Path) -> Pa
 
 
 # ── Filesystem fixtures ───────────────────────────────────────────────────
+
 
 def _make_video(p: Path, size: int = 1024) -> None:
     p.parent.mkdir(parents=True, exist_ok=True)
@@ -123,7 +124,9 @@ def media_tree(tmp_path: Path) -> dict[str, Path]:
 
 
 @pytest.fixture
-def patch_paths(monkeypatch: pytest.MonkeyPatch, media_tree: dict[str, Path]) -> dict[str, Path]:
+def patch_paths(
+    monkeypatch: pytest.MonkeyPatch, media_tree: dict[str, Path]
+) -> dict[str, Path]:
     """Repoint every module's MEDIA_ROOT / SYNC_ROOT binding at the fixture tree.
 
     Each module imports the path once at module-load, so config-level patching
@@ -141,10 +144,20 @@ def patch_paths(monkeypatch: pytest.MonkeyPatch, media_tree: dict[str, Path]) ->
     monkeypatch.setattr("synclet.sync_ops.SYNC_ROOT", sync)
     monkeypatch.setattr("synclet.state.SYNC_ROOT", sync)
     monkeypatch.setattr("synclet.fs_helpers.SYNC_ROOT", sync)
-    monkeypatch.setattr("synclet.config.THUMB_CACHE", media_tree["tmp"] / ".thumb-cache")
+    monkeypatch.setattr("synclet.pending.SYNC_ROOT", sync)
+    monkeypatch.setattr(
+        "synclet.config.THUMB_CACHE", media_tree["tmp"] / ".thumb-cache"
+    )
+    # Snapshot file for the pending module. Default lives under /app/data
+    # which only exists inside the backend container; point at tmp so sync_ops
+    # tests that mutate the snapshot don't try to write into that path.
+    snapshot = media_tree["tmp"] / "snapshot.json"
+    monkeypatch.setattr("synclet.config.SNAPSHOT_FILE", snapshot)
+    monkeypatch.setattr("synclet.pending.SNAPSHOT_FILE", snapshot)
 
     # State cache holds previous-test data; invalidate every test.
     from synclet import state as state_mod
+
     state_mod.invalidate()
     yield media_tree
     state_mod.invalidate()

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -10,16 +10,26 @@ from litestar.testing import TestClient
 
 
 @pytest.fixture
-def client(patch_paths, patch_watchstate, monkeypatch):
+def client(patch_paths, patch_watchstate, tmp_path, monkeypatch):
     """A TestClient pointed at the real Litestar app, with paths repointed
     at the fixture tree and Plex calls mocked away."""
     # Stub Plex API so tests don't depend on network
     monkeypatch.setattr("synclet.plex._get_xml", lambda *a, **kw: None)
     # Reset Plex section_index cache (lru_cache)
-    from synclet.plex import section_index
+    from synclet.plex import episode_rating_keys, section_index
+
     section_index.cache_clear()
+    episode_rating_keys.cache_clear()
+
+    # Point the snapshot at a tmp file so the test does not write into
+    # /app/data on the dev machine (which may not exist or may collide with
+    # the live stack).
+    snap = tmp_path / "snapshot.json"
+    monkeypatch.setattr("synclet.config.SNAPSHOT_FILE", snap)
+    monkeypatch.setattr("synclet.pending.SNAPSHOT_FILE", snap)
 
     from main import app
+
     with TestClient(app=app) as c:
         yield c
 
@@ -53,9 +63,18 @@ class TestStateRoute:
         t = body["titles"][0]
         # Wire-contract fields the frontend types.ts depends on
         required = {
-            "id", "lib", "folder", "name", "kind", "year",
-            "ep_count", "synced_files", "has_synced",
-            "watched_count", "watched_pct", "synced_pct",
+            "id",
+            "lib",
+            "folder",
+            "name",
+            "kind",
+            "year",
+            "ep_count",
+            "synced_files",
+            "has_synced",
+            "watched_count",
+            "watched_pct",
+            "synced_pct",
         }
         assert required <= t.keys(), f"missing: {required - t.keys()}"
 
@@ -91,11 +110,14 @@ class TestTitleRoute:
 class TestSyncRoute:
     def test_no_matches_returns_error_field(self, client):
         # Empty selection — no files match
-        r = client.post("/api/sync", json={
-            "lib": "tv",
-            "folder": "Does Not Exist",
-            "selection_type": "all",
-        })
+        r = client.post(
+            "/api/sync",
+            json={
+                "lib": "tv",
+                "folder": "Does Not Exist",
+                "selection_type": "all",
+            },
+        )
         body = r.json()
         assert body["job_id"] is None
         assert "error" in body
@@ -103,17 +125,159 @@ class TestSyncRoute:
     def test_response_shape_includes_media_files(self, client):
         """The toasts ('5 items') depend on total_media_files being in the
         response. If the field disappears, the UI silently says '0 items'."""
-        r = client.post("/api/sync", json={
-            "lib": "tv",
-            "folder": "Better Call Saul (2015) {tvdb-1}",
-            "selection_type": "episodes",
-            "episodes": [[1, 1]],
-        })
+        r = client.post(
+            "/api/sync",
+            json={
+                "lib": "tv",
+                "folder": "Better Call Saul (2015) {tvdb-1}",
+                "selection_type": "episodes",
+                "episodes": [[1, 1]],
+            },
+        )
         body = r.json()
         # Either error path or success path — both should have predictable shape
         if body.get("job_id"):
             assert "total_media_files" in body
             assert "total_bytes" in body
+
+
+class TestMaintenancePendingRoute:
+    def test_empty_initially(self, client):
+        # First call bootstraps the snapshot from current disk state.
+        # Pre-seeded After Life is in snapshot AND on disk -> no pending.
+        r = client.get("/api/maintenance/pending")
+        assert r.status_code == 200
+        assert r.json()["items"] == []
+
+    def test_deletion_shows_up(self, client, patch_paths):
+        from synclet.pending import SnapshotKey, save_snapshot
+
+        save_snapshot(
+            {
+                SnapshotKey(
+                    sync_sub="tv",
+                    folder="After Life (2019) {tvdb-2}",
+                    season=1,
+                    episode=1,
+                ),
+                SnapshotKey(sync_sub="tv", folder="Ghost", season=1, episode=2),
+            }
+        )
+        r = client.get("/api/maintenance/pending")
+        body = r.json()
+        # Only the ghost (not the After Life that's still on disk)
+        assert len(body["items"]) == 1
+        g = body["items"][0]
+        # ── Wire contract: MaintenanceView.vue + types.ts:PendingGroup ──────
+        # These exact field names are consumed by the frontend. Renaming any
+        # of them without a matching frontend change silently breaks the UI;
+        # this assertion is the contract test for that seam.
+        required_group = {
+            "sync_sub", "folder", "title", "kind", "lib", "rating_key", "seasons",
+        }
+        assert required_group <= g.keys(), f"missing group fields: {required_group - g.keys()}"
+        assert g["folder"] == "Ghost"
+        assert g["kind"] == "show", "frontend dispatches on kind == 'movie' | 'show' | 'youtube'"
+
+        required_season = {"season", "episodes"}
+        s = g["seasons"][0]
+        assert required_season <= s.keys(), f"missing season fields: {required_season - s.keys()}"
+
+        required_episode = {
+            "season", "episode", "already_watched_in_plex", "episode_rating_key", "title",
+        }
+        e = s["episodes"][0]
+        assert required_episode <= e.keys(), (
+            f"missing episode fields: {required_episode - e.keys()}"
+        )
+        assert e["episode"] == 2
+
+    def test_movie_wire_shape(self, client, patch_paths):
+        """A movie group has no `seasons` key; frontend dispatches on `kind`."""
+        from synclet.pending import SnapshotKey, save_snapshot
+
+        save_snapshot({SnapshotKey(sync_sub="movies", folder="Ghost Movie")})
+        r = client.get("/api/maintenance/pending")
+        body = r.json()
+        movie = next(g for g in body["items"] if g["folder"] == "Ghost Movie")
+        # Movie shape distinct from show shape: no seasons, has already_watched_in_plex
+        # at the group level (since a movie is one media item, not a tree).
+        assert movie["kind"] == "movie"
+        assert "seasons" not in movie
+        assert "already_watched_in_plex" in movie
+
+
+class TestMaintenanceResolveRoute:
+    def test_reject_clears_snapshot_entry(self, client, monkeypatch, patch_paths):
+        from synclet.pending import SnapshotKey, load_snapshot, save_snapshot
+
+        save_snapshot({SnapshotKey(sync_sub="tv", folder="Ghost", season=1, episode=1)})
+        monkeypatch.setattr(
+            "synclet.plex.scrobble",
+            lambda *a, **kw: pytest.fail("reject must not scrobble"),
+        )
+
+        r = client.post(
+            "/api/maintenance/resolve",
+            json={
+                "items": [
+                    {
+                        "sync_sub": "tv",
+                        "folder": "Ghost",
+                        "season": 1,
+                        "episode": 1,
+                    }
+                ],
+                "action": "reject",
+            },
+        )
+        assert r.status_code == 201
+        body = r.json()
+        assert body["results"][0]["status"] == "rejected"
+        assert load_snapshot() == set()
+
+    def test_confirm_calls_scrobble_and_returns_per_item_status(
+        self, client, monkeypatch, patch_paths
+    ):
+        """Confirm path: scrobble fires per item, status reflects success/failure."""
+        from synclet.pending import SnapshotKey, load_snapshot, save_snapshot
+
+        calls: list[str] = []
+
+        def _scrobble(rating_key, **_kw):
+            calls.append(rating_key)
+            return True
+
+        monkeypatch.setattr("synclet.plex.scrobble", _scrobble)
+        monkeypatch.setattr(
+            "synclet.plex.find_in_library",
+            lambda lib, folder: {"ratingKey": "777"} if folder == "Movie X" else None,
+        )
+        (patch_paths["media"] / "movies" / "Movie X").mkdir(parents=True)
+
+        save_snapshot({SnapshotKey(sync_sub="movies", folder="Movie X")})
+
+        r = client.post(
+            "/api/maintenance/resolve",
+            json={
+                "items": [{"sync_sub": "movies", "folder": "Movie X"}],
+                "action": "confirm",
+            },
+        )
+        assert r.status_code == 201
+        body = r.json()
+        assert body["results"][0]["status"] == "ok"
+        assert calls == ["777"]
+        assert load_snapshot() == set()
+
+    def test_unknown_action_returns_error(self, client):
+        r = client.post(
+            "/api/maintenance/resolve",
+            json={"items": [], "action": "explode"},
+        )
+        body = r.json()
+        assert "error" in body
+        assert body["results"] == []
 
 
 class TestResolveRoute:
@@ -135,6 +299,7 @@ class TestResolveRoute:
         the modal, users see raw codes."""
         # Reasons that need to round-trip
         from synclet.resolve import resolve_url
+
         for url, expected_reason in [
             ("", "empty"),
             ("https://www.imdb.com/title/tt9/", "imdb_url_unsupported"),

--- a/backend/tests/test_fuzzy.py
+++ b/backend/tests/test_fuzzy.py
@@ -46,9 +46,9 @@ class TestFuzzyScore:
         # the precise target higher than a partial one.
         scores = [
             ("better call saul", "Better Call Saul"),  # exact
-            ("better call",      "Better Call Saul"),  # substring
-            ("call",             "Better Call Saul"),  # substring
-            ("xyz",              "Better Call Saul"),  # no match
+            ("better call", "Better Call Saul"),  # substring
+            ("call", "Better Call Saul"),  # substring
+            ("xyz", "Better Call Saul"),  # no match
         ]
         results = [fuzzy_score(q, t) for q, t in scores]
         assert results == sorted(results, reverse=True), f"Not monotonic: {results}"

--- a/backend/tests/test_pending.py
+++ b/backend/tests/test_pending.py
@@ -1,0 +1,405 @@
+"""Tests for deletion-driven watch-state write-back (synclet.pending).
+
+The flow is: snapshot.json tracks what Synclet thinks is on disk; pending =
+snapshot - on-disk. Resolve (confirm or reject) drops from the snapshot,
+confirm additionally scrobbles. The bootstrap path means first-ever run
+produces zero pending so existing libraries are not flagged as deletions.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from synclet import pending as pending_mod
+from synclet.pending import (
+    SnapshotKey,
+    add_keys,
+    bootstrap_if_missing,
+    compute_pending,
+    keys_for_paths,
+    load_snapshot,
+    path_to_snapshot_key,
+    remove_keys,
+    resolve,
+    save_snapshot,
+)
+
+
+@pytest.fixture
+def patch_snapshot(monkeypatch, tmp_path: Path) -> Path:
+    """Point SNAPSHOT_FILE at a temp dir.
+
+    Re-binds every module that imported the constant. Without this the test
+    would write to /app/data/snapshot.json, which (a) may not exist on
+    pocket-dev and (b) would leak state between tests.
+    """
+    snap = tmp_path / "snapshot.json"
+    monkeypatch.setattr("synclet.config.SNAPSHOT_FILE", snap)
+    monkeypatch.setattr("synclet.pending.SNAPSHOT_FILE", snap)
+    return snap
+
+
+# ── path_to_snapshot_key ────────────────────────────────────────────────────
+
+
+class TestPathToSnapshotKey:
+    def test_show_episode(self, patch_paths):
+        path = (
+            patch_paths["sync"]
+            / "tv"
+            / "Better Call Saul (2015) {tvdb-1}"
+            / "Season 01"
+            / "Better Call Saul - S01E03 - Whatever.mkv"
+        )
+        key = path_to_snapshot_key(path)
+        assert key == SnapshotKey(
+            sync_sub="tv",
+            folder="Better Call Saul (2015) {tvdb-1}",
+            season=1,
+            episode=3,
+        )
+
+    def test_movie(self, patch_paths):
+        path = (
+            patch_paths["sync"] / "movies" / "1917 (2019) {tmdb-3}" / "1917.mkv"
+        )
+        key = path_to_snapshot_key(path)
+        assert key == SnapshotKey(sync_sub="movies", folder="1917 (2019) {tmdb-3}")
+
+    def test_non_video_returns_none(self, patch_paths):
+        path = (
+            patch_paths["sync"]
+            / "tv"
+            / "Foo"
+            / "Season 01"
+            / "Foo - S01E01.srt"
+        )
+        assert path_to_snapshot_key(path) is None
+
+    def test_path_outside_sync_root_returns_none(self, patch_paths, tmp_path: Path):
+        elsewhere = tmp_path / "not-sync" / "thing.mkv"
+        assert path_to_snapshot_key(elsewhere) is None
+
+    def test_unknown_sync_sub_returns_none(self, patch_paths):
+        path = patch_paths["sync"] / "totally-unknown-sub" / "X" / "X.mkv"
+        path.parent.mkdir(parents=True)
+        path.write_bytes(b"")
+        assert path_to_snapshot_key(path) is None
+
+
+# ── load/save snapshot ──────────────────────────────────────────────────────
+
+
+class TestSnapshotIO:
+    def test_load_empty_when_missing(self, patch_snapshot):
+        assert load_snapshot() == set()
+
+    def test_roundtrip(self, patch_snapshot):
+        keys = {
+            SnapshotKey(sync_sub="tv", folder="Foo", season=1, episode=1),
+            SnapshotKey(sync_sub="movies", folder="Bar"),
+        }
+        save_snapshot(keys)
+        assert load_snapshot() == keys
+
+    def test_load_returns_empty_on_corrupt_json(self, patch_snapshot):
+        patch_snapshot.parent.mkdir(parents=True, exist_ok=True)
+        patch_snapshot.write_text("{not valid json")
+        assert load_snapshot() == set()
+
+    def test_save_is_atomic(self, patch_snapshot):
+        """The tempfile-then-rename pattern leaves no .tmp behind on success."""
+        save_snapshot({SnapshotKey(sync_sub="tv", folder="X", season=1, episode=1)})
+        siblings = list(patch_snapshot.parent.iterdir())
+        assert not any(s.name.endswith(".tmp") for s in siblings)
+
+
+# ── bootstrap ───────────────────────────────────────────────────────────────
+
+
+class TestBootstrap:
+    def test_first_run_creates_snapshot_matching_disk(
+        self, patch_snapshot, patch_paths
+    ):
+        # The patch_paths fixture pre-seeded an After Life synced copy.
+        assert not patch_snapshot.exists()
+        fired = bootstrap_if_missing()
+        assert fired is True
+        snap = load_snapshot()
+        assert snap == {
+            SnapshotKey(
+                sync_sub="tv",
+                folder="After Life (2019) {tvdb-2}",
+                season=1,
+                episode=1,
+            ),
+        }
+
+    def test_second_call_is_noop(self, patch_snapshot, patch_paths):
+        bootstrap_if_missing()
+        # Mutate the snapshot directly and re-bootstrap; it must NOT overwrite.
+        save_snapshot({SnapshotKey(sync_sub="movies", folder="Foo")})
+        assert bootstrap_if_missing() is False
+        assert load_snapshot() == {SnapshotKey(sync_sub="movies", folder="Foo")}
+
+
+# ── pending diff ────────────────────────────────────────────────────────────
+
+
+class TestComputePending:
+    def test_no_pending_immediately_after_bootstrap(
+        self, patch_snapshot, patch_paths
+    ):
+        bootstrap_if_missing()
+        assert compute_pending() == set()
+
+    def test_deletion_surfaces_as_pending(self, patch_snapshot, patch_paths):
+        # Seed snapshot with an item that doesn't exist on disk.
+        save_snapshot(
+            {SnapshotKey(sync_sub="tv", folder="Ghost Show", season=1, episode=1)}
+        )
+        pending_set = compute_pending()
+        assert pending_set == {
+            SnapshotKey(sync_sub="tv", folder="Ghost Show", season=1, episode=1)
+        }
+
+    def test_restored_file_disappears_from_pending(self, patch_snapshot, patch_paths):
+        # Pre-existing After Life file is in snapshot AND on disk -> no pending.
+        save_snapshot(
+            {
+                SnapshotKey(
+                    sync_sub="tv",
+                    folder="After Life (2019) {tvdb-2}",
+                    season=1,
+                    episode=1,
+                ),
+                SnapshotKey(
+                    sync_sub="tv",
+                    folder="Ghost Show",
+                    season=1,
+                    episode=1,
+                ),
+            }
+        )
+        # Only the ghost should be pending.
+        assert compute_pending() == {
+            SnapshotKey(sync_sub="tv", folder="Ghost Show", season=1, episode=1)
+        }
+
+
+# ── keys_for_paths (used by sync_ops.remove_files) ──────────────────────────
+
+
+class TestKeysForPaths:
+    def test_drops_non_video(self, patch_paths):
+        sync = patch_paths["sync"]
+        srt = sync / "tv" / "X" / "Season 01" / "X - S01E01.srt"
+        mkv = sync / "tv" / "X" / "Season 01" / "X - S01E01.mkv"
+        keys = keys_for_paths([str(srt), str(mkv)])
+        assert keys == {
+            SnapshotKey(sync_sub="tv", folder="X", season=1, episode=1)
+        }
+
+    def test_drops_paths_outside_sync_root(self, patch_paths, tmp_path: Path):
+        outside = tmp_path / "elsewhere" / "S01E01.mkv"
+        assert keys_for_paths([str(outside)]) == set()
+
+
+# ── add_keys / remove_keys ──────────────────────────────────────────────────
+
+
+class TestSnapshotMutation:
+    def test_add_keys_bootstraps_if_needed(self, patch_snapshot, patch_paths):
+        # Pre-existing After Life on disk; add_keys should bootstrap first.
+        assert not patch_snapshot.exists()
+        new = SnapshotKey(sync_sub="tv", folder="New Show", season=1, episode=1)
+        add_keys({new})
+        snap = load_snapshot()
+        # After Life from bootstrap PLUS the new key.
+        assert new in snap
+        assert any(k.folder == "After Life (2019) {tvdb-2}" for k in snap)
+
+    def test_remove_keys_idempotent_when_absent(self, patch_snapshot):
+        save_snapshot({SnapshotKey(sync_sub="tv", folder="A", season=1, episode=1)})
+        remove_keys(
+            {SnapshotKey(sync_sub="tv", folder="Not There", season=1, episode=1)}
+        )
+        assert load_snapshot() == {
+            SnapshotKey(sync_sub="tv", folder="A", season=1, episode=1)
+        }
+
+    def test_empty_inputs_are_noops(self, patch_snapshot):
+        # Empty add_keys must not touch the file (no spurious bootstrap or write).
+        add_keys([])
+        assert not patch_snapshot.exists()
+
+
+# ── resolve ─────────────────────────────────────────────────────────────────
+
+
+class TestResolveReject:
+    def test_reject_drops_from_snapshot_no_scrobble(
+        self, patch_snapshot, patch_paths, monkeypatch
+    ):
+        # If scrobble were called we'd see it; the spy raises.
+        def _boom(*_a, **_kw):
+            msg = "scrobble must not be called on reject"
+            raise AssertionError(msg)
+
+        monkeypatch.setattr("synclet.plex.scrobble", _boom)
+
+        k = SnapshotKey(sync_sub="tv", folder="X", season=1, episode=1)
+        save_snapshot({k})
+        results = resolve([k], confirm=False)
+        assert [r.status for r in results] == ["rejected"]
+        assert load_snapshot() == set()
+
+
+class TestResolveConfirm:
+    def test_confirm_with_mocked_scrobble(
+        self, patch_snapshot, patch_paths, monkeypatch
+    ):
+        called: list[str] = []
+
+        def _ok(rating_key: str, **_kw) -> bool:
+            called.append(rating_key)
+            return True
+
+        # Stub the Plex lookups; movie resolves directly off section_index.
+        monkeypatch.setattr("synclet.plex.scrobble", _ok)
+        monkeypatch.setattr(
+            "synclet.plex.find_in_library",
+            lambda lib, folder: {"ratingKey": "9000"} if folder == "Movie X" else None,
+        )
+
+        # Seed: a movie pending. find_source_lib resolves via MEDIA_ROOT,
+        # which we'll satisfy by creating the source folder.
+        (patch_paths["media"] / "movies" / "Movie X").mkdir(parents=True)
+        k = SnapshotKey(sync_sub="movies", folder="Movie X")
+        save_snapshot({k})
+
+        results = resolve([k], confirm=True)
+        assert [r.status for r in results] == ["ok"]
+        assert called == ["9000"]
+        assert load_snapshot() == set()
+
+    def test_scrobble_failure_still_drops_from_snapshot(
+        self, patch_snapshot, patch_paths, monkeypatch
+    ):
+        # Plex unreachable -> scrobble returns False. We still drop from
+        # snapshot, since the file is already gone from disk.
+        monkeypatch.setattr("synclet.plex.scrobble", lambda *a, **kw: False)
+        monkeypatch.setattr(
+            "synclet.plex.find_in_library",
+            lambda lib, folder: {"ratingKey": "9000"} if folder == "Movie X" else None,
+        )
+
+        (patch_paths["media"] / "movies" / "Movie X").mkdir(parents=True)
+        k = SnapshotKey(sync_sub="movies", folder="Movie X")
+        save_snapshot({k})
+
+        results = resolve([k], confirm=True)
+        assert [r.status for r in results] == ["scrobble_failed"]
+        assert load_snapshot() == set()
+
+    def test_confirm_for_show_episode_uses_episode_rating_key(
+        self, patch_snapshot, patch_paths, monkeypatch
+    ):
+        """Show episode confirm: show ratingKey -> allLeaves -> episode key -> scrobble.
+
+        This path is structurally different from movie confirm (which scrobbles
+        the show-level ratingKey directly): show confirm has to drill into
+        episode_rating_keys to find the EPISODE's ratingKey.
+        """
+        called: list[str] = []
+
+        def _ok(rating_key: str, **_kw) -> bool:
+            called.append(rating_key)
+            return True
+
+        monkeypatch.setattr("synclet.plex.scrobble", _ok)
+        monkeypatch.setattr(
+            "synclet.plex.find_in_library",
+            lambda lib, folder: (
+                {"ratingKey": "SHOW100"} if folder == "Ghost Show" else None
+            ),
+        )
+        monkeypatch.setattr(
+            "synclet.plex.episode_rating_keys",
+            lambda show_rk: {(1, 3): "EP-1-3"} if show_rk == "SHOW100" else {},
+        )
+
+        (patch_paths["media"] / "tv" / "Ghost Show").mkdir(parents=True)
+        k = SnapshotKey(sync_sub="tv", folder="Ghost Show", season=1, episode=3)
+        save_snapshot({k})
+
+        results = resolve([k], confirm=True)
+        assert [r.status for r in results] == ["ok"]
+        # Must be the EPISODE ratingKey, not the show's. This is the trap the
+        # initial design comment got wrong before live-testing surfaced it.
+        assert called == ["EP-1-3"]
+        assert load_snapshot() == set()
+
+    def test_no_rating_key_when_plex_returns_nothing(
+        self, patch_snapshot, patch_paths, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "synclet.plex.scrobble",
+            lambda *a, **kw: pytest.fail("must not be called without rating key"),
+        )
+        monkeypatch.setattr("synclet.plex.find_in_library", lambda *a, **kw: None)
+
+        (patch_paths["media"] / "movies" / "Movie X").mkdir(parents=True)
+        k = SnapshotKey(sync_sub="movies", folder="Movie X")
+        save_snapshot({k})
+
+        results = resolve([k], confirm=True)
+        assert [r.status for r in results] == ["no_rating_key"]
+        # Snapshot still cleared — the file is gone, leaving it in pending
+        # would re-prompt the user every page load.
+        assert load_snapshot() == set()
+
+
+# ── grouped_pending wire shape ──────────────────────────────────────────────
+
+
+class TestGroupedPending:
+    def test_movie_entry_shape(self, patch_snapshot, patch_paths, monkeypatch):
+        monkeypatch.setattr("synclet.plex.find_in_library", lambda *a, **kw: None)
+        monkeypatch.setattr(
+            "synclet.plex.episode_rating_keys", lambda show_rk: {}
+        )
+        (patch_paths["media"] / "movies" / "Ghost Movie").mkdir(parents=True)
+        save_snapshot({SnapshotKey(sync_sub="movies", folder="Ghost Movie")})
+
+        groups = pending_mod.grouped_pending()
+        assert len(groups) == 1
+        g = groups[0]
+        assert g["sync_sub"] == "movies"
+        assert g["folder"] == "Ghost Movie"
+        assert g["kind"] == "movie"
+        assert g["title"] == "Ghost Movie"
+        assert "rating_key" in g
+        assert "already_watched_in_plex" in g
+
+    def test_show_entry_groups_by_season(self, patch_snapshot, patch_paths, monkeypatch):
+        monkeypatch.setattr("synclet.plex.find_in_library", lambda *a, **kw: None)
+        monkeypatch.setattr("synclet.plex.episode_rating_keys", lambda show_rk: {})
+        (patch_paths["media"] / "tv" / "Ghost Show").mkdir(parents=True)
+        save_snapshot(
+            {
+                SnapshotKey(sync_sub="tv", folder="Ghost Show", season=1, episode=1),
+                SnapshotKey(sync_sub="tv", folder="Ghost Show", season=1, episode=2),
+                SnapshotKey(sync_sub="tv", folder="Ghost Show", season=2, episode=1),
+            }
+        )
+
+        groups = pending_mod.grouped_pending()
+        assert len(groups) == 1
+        seasons = groups[0]["seasons"]
+        s_nums = [s["season"] for s in seasons]
+        assert s_nums == [1, 2]
+        assert len(seasons[0]["episodes"]) == 2
+        assert len(seasons[1]["episodes"]) == 1

--- a/backend/tests/test_plex.py
+++ b/backend/tests/test_plex.py
@@ -32,10 +32,17 @@ _FAKE_TV_SECTION_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
 
 def _mock_urlopen(_):
     """Return an object whose .read() yields our fixture XML."""
+
     class _Resp:
-        def __enter__(self): return self
-        def __exit__(self, *a): pass
-        def read(self): return _FAKE_TV_SECTION_XML
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+        def read(self):
+            return _FAKE_TV_SECTION_XML
+
     return _Resp()
 
 
@@ -44,13 +51,17 @@ class TestSectionIndex:
         section_index.cache_clear()
 
     def test_parses_directory_entries(self, monkeypatch):
-        monkeypatch.setattr("synclet.plex.urllib.request.urlopen", lambda *a, **kw: _mock_urlopen(None))
+        monkeypatch.setattr(
+            "synclet.plex.urllib.request.urlopen", lambda *a, **kw: _mock_urlopen(None)
+        )
         idx = section_index(2)
         assert "better call saul" in idx
         assert "after life" in idx
 
     def test_extracts_thumb_and_art(self, monkeypatch):
-        monkeypatch.setattr("synclet.plex.urllib.request.urlopen", lambda *a, **kw: _mock_urlopen(None))
+        monkeypatch.setattr(
+            "synclet.plex.urllib.request.urlopen", lambda *a, **kw: _mock_urlopen(None)
+        )
         idx = section_index(2)
         bcs = idx["better call saul"]
         assert bcs["thumb"] == "/library/metadata/100/thumb/123"
@@ -61,12 +72,15 @@ class TestSectionIndex:
     def test_handles_api_failure(self, monkeypatch):
         def _raise(*a, **kw):
             raise OSError("network gone")
+
         monkeypatch.setattr("synclet.plex.urllib.request.urlopen", _raise)
         idx = section_index(99)  # different id → cache miss
         assert idx == {}
 
     def test_find_in_library_with_year_in_folder(self, monkeypatch):
-        monkeypatch.setattr("synclet.plex.urllib.request.urlopen", lambda *a, **kw: _mock_urlopen(None))
+        monkeypatch.setattr(
+            "synclet.plex.urllib.request.urlopen", lambda *a, **kw: _mock_urlopen(None)
+        )
         # Folder name has year + tvdb cruft; lookup key should be normalized
         result = find_in_library("tv", "Better Call Saul (2015) {tvdb-1}")
         assert result is not None
@@ -74,3 +88,112 @@ class TestSectionIndex:
 
     def test_find_in_library_unknown_lib(self):
         assert find_in_library("nonexistent", "anything") is None
+
+
+# ── Episode ratingKey + scrobble ─────────────────────────────────────────────
+
+
+_FAKE_ALL_LEAVES_XML = b"""<?xml version="1.0" encoding="UTF-8"?>
+<MediaContainer size="3">
+<Video ratingKey="1001" parentIndex="1" index="1" type="episode" title="Uno"/>
+<Video ratingKey="1002" parentIndex="1" index="2" type="episode" title="Mijo"/>
+<Video ratingKey="2001" parentIndex="2" index="1" type="episode" title="Switch"/>
+</MediaContainer>
+"""
+
+
+class _AllLeavesResp:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        pass
+
+    def read(self):
+        return _FAKE_ALL_LEAVES_XML
+
+
+class TestEpisodeRatingKeys:
+    def setup_method(self):
+        from synclet.plex import episode_rating_keys
+
+        episode_rating_keys.cache_clear()
+
+    def test_returns_mapping(self, monkeypatch):
+        from synclet.plex import episode_rating_keys
+
+        monkeypatch.setattr(
+            "synclet.plex.urllib.request.urlopen", lambda *a, **kw: _AllLeavesResp()
+        )
+        m = episode_rating_keys("100")
+        assert m[(1, 1)] == "1001"
+        assert m[(1, 2)] == "1002"
+        assert m[(2, 1)] == "2001"
+
+    def test_handles_api_failure(self, monkeypatch):
+        from synclet.plex import episode_rating_keys
+
+        def _raise(*_a, **_kw):
+            raise OSError("network gone")
+
+        monkeypatch.setattr("synclet.plex.urllib.request.urlopen", _raise)
+        # Different key -> cache miss -> empty.
+        assert episode_rating_keys("999") == {}
+
+
+class _ScrobbleResp:
+    status = 200
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        pass
+
+
+class TestScrobble:
+    def test_calls_plex_with_identifier_and_key(self, monkeypatch):
+        from synclet.plex import scrobble
+
+        captured: list[str] = []
+
+        def _capture(url, timeout=8):
+            captured.append(url)
+            return _ScrobbleResp()
+
+        monkeypatch.setattr("synclet.plex.urllib.request.urlopen", _capture)
+        ok = scrobble("4242")
+        assert ok is True
+        assert len(captured) == 1
+        u = captured[0]
+        assert "/:/scrobble" in u
+        assert "identifier=com.plexapp.plugins.library" in u
+        assert "key=4242" in u
+        # The X-Plex-Token query parameter must be present (auth)
+        assert "X-Plex-Token=" in u
+
+    def test_returns_false_on_network_error(self, monkeypatch):
+        from synclet.plex import scrobble
+
+        def _raise(*_a, **_kw):
+            raise OSError("network gone")
+
+        monkeypatch.setattr("synclet.plex.urllib.request.urlopen", _raise)
+        assert scrobble("4242") is False
+
+    def test_returns_false_on_non_2xx(self, monkeypatch):
+        from synclet.plex import scrobble
+
+        class _Resp404:
+            status = 404
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_):
+                pass
+
+        monkeypatch.setattr(
+            "synclet.plex.urllib.request.urlopen", lambda *a, **kw: _Resp404()
+        )
+        assert scrobble("4242") is False

--- a/backend/tests/test_resolve.py
+++ b/backend/tests/test_resolve.py
@@ -13,6 +13,7 @@ from synclet.resolve import resolve_url
 def state_loaded(patch_paths, patch_watchstate):
     """Force the state cache to warm up so _by_name has data to search."""
     from synclet.state import get_state
+
     get_state(force=True)
 
 
@@ -47,33 +48,43 @@ class TestResolveUrl:
     def test_plex_url_metadata_fail(self, state_loaded, monkeypatch):
         """When the Plex API call fails, we surface a clear reason rather than crash."""
         monkeypatch.setattr("synclet.resolve.get_metadata", lambda _: None)
-        r = resolve_url("https://app.plex.tv/desktop/#!/details?key=%2Flibrary%2Fmetadata%2F12345")
+        r = resolve_url(
+            "https://app.plex.tv/desktop/#!/details?key=%2Flibrary%2Fmetadata%2F12345"
+        )
         assert r["found"] is False
         assert r["reason"] == "plex_metadata_lookup_failed"
         assert r["ratingKey"] == "12345"
 
     def test_plex_show_url(self, state_loaded, monkeypatch):
         """Plex returns a show; we map back to local folder via title."""
-        monkeypatch.setattr("synclet.resolve.get_metadata", lambda _: {
-            "ratingKey": "12345",
-            "title": "Better Call Saul",
-            "type": "show",
-            "location": None,
-        })
-        r = resolve_url("https://app.plex.tv/desktop/#!/details?key=%2Flibrary%2Fmetadata%2F12345")
+        monkeypatch.setattr(
+            "synclet.resolve.get_metadata",
+            lambda _: {
+                "ratingKey": "12345",
+                "title": "Better Call Saul",
+                "type": "show",
+                "location": None,
+            },
+        )
+        r = resolve_url(
+            "https://app.plex.tv/desktop/#!/details?key=%2Flibrary%2Fmetadata%2F12345"
+        )
         assert r["found"] is True
         assert r["name"] == "Better Call Saul (2015)"
         assert r["via"] == "plex_metadata"
 
     def test_plex_episode_walks_to_show(self, state_loaded, monkeypatch):
         """For an episode-type metadata key, we use grandparentTitle (the show)."""
-        monkeypatch.setattr("synclet.resolve.get_metadata", lambda _: {
-            "ratingKey": "99",
-            "title": "Uno",
-            "type": "episode",
-            "grandparentTitle": "Better Call Saul",
-            "parentTitle": "Season 1",
-        })
+        monkeypatch.setattr(
+            "synclet.resolve.get_metadata",
+            lambda _: {
+                "ratingKey": "99",
+                "title": "Uno",
+                "type": "episode",
+                "grandparentTitle": "Better Call Saul",
+                "parentTitle": "Season 1",
+            },
+        )
         r = resolve_url("/library/metadata/99")
         assert r["found"] is True
         assert r["name"] == "Better Call Saul (2015)"

--- a/backend/tests/test_scan.py
+++ b/backend/tests/test_scan.py
@@ -27,7 +27,9 @@ class TestCleanName:
         assert clean_name("1917 (2019) {tmdb-530915}") == "1917 (2019)"
 
     def test_keeps_year(self):
-        assert clean_name("Better Call Saul (2015) {tvdb-1}") == "Better Call Saul (2015)"
+        assert (
+            clean_name("Better Call Saul (2015) {tvdb-1}") == "Better Call Saul (2015)"
+        )
 
     def test_no_cruft(self):
         assert clean_name("Fallout") == "Fallout"
@@ -123,8 +125,9 @@ class TestScanTitleDetail:
         assert len(season1.episodes) == 2
         # English sub should be counted; French sub should not show up in files
         e1 = next(e for e in season1.episodes if e.episode == 1)
-        assert all("fr.srt" not in f for f in e1.files), \
+        assert all("fr.srt" not in f for f in e1.files), (
             f"French subtitle leaked through filter: {e1.files}"
+        )
 
     def test_movie_detail(self, patch_paths):
         d = scan_title_detail("movies", "1917 (2019) {tmdb-3}")

--- a/backend/tests/test_sync_ops.py
+++ b/backend/tests/test_sync_ops.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 
 from synclet.sync_ops import (
-    _find_source_lib,
+    find_source_lib,
     _is_video,
     find_hanging_files,
     find_watched_synced_files,
@@ -36,17 +36,18 @@ class TestIsVideo:
 
 class TestFindSourceLib:
     def test_finds_library(self, patch_paths):
-        lib = _find_source_lib("Better Call Saul (2015) {tvdb-1}")
+        lib = find_source_lib("Better Call Saul (2015) {tvdb-1}")
         assert lib == "tv"
 
     def test_returns_none_for_unknown(self, patch_paths):
-        assert _find_source_lib("Does Not Exist") is None
+        assert find_source_lib("Does Not Exist") is None
 
 
 class TestResolveSelection:
     def test_all_show_files(self, patch_paths):
         pairs = resolve_selection(
-            "tv", "Better Call Saul (2015) {tvdb-1}",
+            "tv",
+            "Better Call Saul (2015) {tvdb-1}",
             selection_type="all",
         )
         # 2 video files + 1 English sub = 3 (French sub dropped by is_wanted_file)
@@ -58,7 +59,8 @@ class TestResolveSelection:
 
     def test_single_episode(self, patch_paths):
         pairs = resolve_selection(
-            "tv", "Better Call Saul (2015) {tvdb-1}",
+            "tv",
+            "Better Call Saul (2015) {tvdb-1}",
             selection_type="episodes",
             episodes=[[1, 1]],
         )
@@ -70,7 +72,8 @@ class TestResolveSelection:
 
     def test_movie_selection(self, patch_paths):
         pairs = resolve_selection(
-            "movies", "1917 (2019) {tmdb-3}",
+            "movies",
+            "1917 (2019) {tmdb-3}",
             selection_type="movie",
         )
         names = [src.name for src, _ in pairs]
@@ -84,7 +87,8 @@ class TestResolveSelection:
 
     def test_dst_mirrors_lib_subfolder(self, patch_paths):
         pairs = resolve_selection(
-            "tv", "Better Call Saul (2015) {tvdb-1}",
+            "tv",
+            "Better Call Saul (2015) {tvdb-1}",
             selection_type="episodes",
             episodes=[[1, 1]],
         )
@@ -98,7 +102,8 @@ class TestSyncJob:
     async def test_copy_then_unsync(self, patch_paths):
         # Sync S01E01 of BCS
         pairs = resolve_selection(
-            "tv", "Better Call Saul (2015) {tvdb-1}",
+            "tv",
+            "Better Call Saul (2015) {tvdb-1}",
             selection_type="episodes",
             episodes=[[1, 1]],
         )
@@ -113,7 +118,9 @@ class TestSyncJob:
 
         assert job.status == "done", f"job ended with {job.status}: {job.error}"
         assert job.processed_files > 0
-        assert job.processed_media_files >= 1, "at least one video should have been copied"
+        assert job.processed_media_files >= 1, (
+            "at least one video should have been copied"
+        )
 
         # Verify the file actually landed
         first_dst = Path(job.items[0]["dst"])
@@ -125,7 +132,8 @@ class TestSyncJob:
 
         # Now unsync the same episode
         unsync_pairs = resolve_selection(
-            "tv", "Better Call Saul (2015) {tvdb-1}",
+            "tv",
+            "Better Call Saul (2015) {tvdb-1}",
             selection_type="episodes",
             episodes=[[1, 1]],
         )
@@ -157,7 +165,9 @@ class TestMaintenance:
         assert any(r.endswith("Other Show/Season 01/ep.srt") for r in rels)
         assert not any(r.endswith("Some Show/Season 01/ep.srt") for r in rels)
 
-    def test_find_watched_finds_synced_watched_movie(self, patch_paths, patch_watchstate):
+    def test_find_watched_finds_synced_watched_movie(
+        self, patch_paths, patch_watchstate
+    ):
         # Pre-sync 1917 (watched=False in fixture) — should NOT appear
         sync = patch_paths["sync"]
         movie_dir = sync / "movies" / "1917 (2019) {tmdb-3}"
@@ -185,3 +195,123 @@ class TestRemoveFiles:
         r = remove_files(["/nonexistent/path"])
         assert r["removed"] == 0
         assert r["bytes_freed"] == 0
+
+
+# ── Snapshot integration (deletion-driven watch-state write-back) ──────────
+#
+# The flows in synclet.pending are unit-tested in test_pending.py against a
+# direct snapshot file. The tests below pin the *integration*: that the
+# sync_ops paths (sync completion, unsync, manual remove) correctly mutate
+# the snapshot in addition to their primary side-effect on disk. Without
+# these, the snapshot could silently drift from disk reality after a refactor.
+
+
+class TestSyncOpsSnapshotIntegration:
+    @pytest.mark.asyncio
+    async def test_sync_completion_adds_to_snapshot(self, patch_paths):
+        from synclet.pending import SnapshotKey, load_snapshot
+
+        # BCS S01E01 isn't pre-seeded into sync/, so syncing it is a new add.
+        pairs = resolve_selection(
+            "tv",
+            "Better Call Saul (2015) {tvdb-1}",
+            selection_type="episodes",
+            episodes=[[1, 1]],
+        )
+        assert pairs
+        job = start_sync(pairs, title="bcs s01e01")
+        for _ in range(50):
+            if job.status in ("done", "error"):
+                break
+            await asyncio.sleep(0.05)
+        assert job.status == "done"
+
+        snap = load_snapshot()
+        # The newly-synced episode must be in the snapshot.
+        assert (
+            SnapshotKey(
+                sync_sub="tv",
+                folder="Better Call Saul (2015) {tvdb-1}",
+                season=1,
+                episode=1,
+            )
+            in snap
+        )
+
+    @pytest.mark.asyncio
+    async def test_unsync_removes_from_snapshot(self, patch_paths):
+        from synclet.pending import SnapshotKey, load_snapshot, save_snapshot
+
+        # Sync first so the file lands on disk AND the snapshot picks it up.
+        pairs = resolve_selection(
+            "tv",
+            "Better Call Saul (2015) {tvdb-1}",
+            selection_type="episodes",
+            episodes=[[1, 1]],
+        )
+        sjob = start_sync(pairs, title="seed")
+        for _ in range(50):
+            if sjob.status in ("done", "error"):
+                break
+            await asyncio.sleep(0.05)
+        target_key = SnapshotKey(
+            sync_sub="tv",
+            folder="Better Call Saul (2015) {tvdb-1}",
+            season=1,
+            episode=1,
+        )
+        assert target_key in load_snapshot()
+
+        # Now unsync that episode — explicit user gesture, not a watched-confirm.
+        upairs = resolve_selection(
+            "tv",
+            "Better Call Saul (2015) {tvdb-1}",
+            selection_type="episodes",
+            episodes=[[1, 1]],
+        )
+        ujob = start_unsync(upairs, title="unsync")
+        for _ in range(50):
+            if ujob.status in ("done", "error"):
+                break
+            await asyncio.sleep(0.05)
+        assert ujob.status == "done"
+
+        # The snapshot must reflect the unsync; the episode is no longer "synced
+        # according to Synclet" so it cannot reappear as pending.
+        assert target_key not in load_snapshot()
+
+        # Sanity: re-seed and check the inverse to make sure we're testing what
+        # we think (save_snapshot is the manual write path).
+        save_snapshot({target_key})
+        assert target_key in load_snapshot()
+
+    def test_remove_files_drops_from_snapshot(self, patch_paths):
+        """The maintenance 'remove watched' path is an implicit confirm.
+
+        When the user clicks Remove on a watched episode, the file is deleted
+        AND the snapshot entry is dropped so it doesn't reappear as pending
+        on the next page load.
+        """
+        from synclet.pending import SnapshotKey, load_snapshot, save_snapshot
+
+        sync = patch_paths["sync"]
+        target = (
+            sync
+            / "tv"
+            / "Some Show"
+            / "Season 01"
+            / "Some Show - S01E01 - X.mkv"
+        )
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"\0" * 50)
+
+        # Pre-seed the snapshot to simulate "this file was tracked".
+        key = SnapshotKey(
+            sync_sub="tv", folder="Some Show", season=1, episode=1
+        )
+        save_snapshot({key})
+        assert key in load_snapshot()
+
+        r = remove_files([str(target)])
+        assert r["removed"] == 1
+        assert key not in load_snapshot()

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.7",
+    "@vue/test-utils": "^2.4.10",
     "@vue/tsconfig": "^0.8.1",
     "happy-dom": "^15.11.0",
     "typescript": "^6.0.3",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
       '@vitejs/plugin-vue':
         specifier: ^6.0.7
         version: 6.0.7(vite@8.0.13)(vue@3.5.34(typescript@6.0.3))
+      '@vue/test-utils':
+        specifier: ^2.4.10
+        version: 2.4.10(@vue/compiler-dom@3.5.34)(@vue/server-renderer@3.5.34(vue@3.5.34(typescript@6.0.3)))(vue@3.5.34(typescript@6.0.3))
       '@vue/tsconfig':
         specifier: ^0.8.1
         version: 0.8.1(typescript@6.0.3)(vue@3.5.34(typescript@6.0.3))
@@ -62,6 +65,10 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
@@ -71,8 +78,15 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@one-ini/wasm@0.1.1':
+    resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
+
   '@oxc-project/types@0.130.0':
     resolution: {integrity: sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@rolldown/binding-android-arm64@1.0.1':
     resolution: {integrity: sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==}
@@ -264,6 +278,16 @@ packages:
   '@vue/shared@3.5.34':
     resolution: {integrity: sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==}
 
+  '@vue/test-utils@2.4.10':
+    resolution: {integrity: sha512-SmoZ5EA1kYiAFs9NkYdiFFQF+cSnUwnvlYEbY+DogWQZUiqOm/Y29eSbc5T6yi75SgSF9863SBeXniIEoPajCA==}
+    peerDependencies:
+      '@vue/compiler-dom': 3.x
+      '@vue/server-renderer': 3.x
+      vue: 3.x
+    peerDependenciesMeta:
+      '@vue/server-renderer':
+        optional: true
+
   '@vue/tsconfig@0.8.1':
     resolution: {integrity: sha512-aK7feIWPXFSUhsCP9PFqPyFOcz4ENkb8hZ2pneL6m2UjCkccvaOhC/5KCKluuBufvp2KzkbdA2W2pk20vLzu3g==}
     peerDependencies:
@@ -275,19 +299,63 @@ packages:
       vue:
         optional: true
 
+  abbrev@2.0.0:
+    resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
   alien-signals@3.2.1:
     resolution: {integrity: sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
+
+  config-chain@1.1.13:
+    resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -295,6 +363,20 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  editorconfig@1.0.7:
+    resolution: {integrity: sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
@@ -326,14 +408,45 @@ packages:
       picomatch:
         optional: true
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
   happy-dom@15.11.7:
     resolution: {integrity: sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==}
     engines: {node: '>=18.0.0'}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  js-beautify@1.15.4:
+    resolution: {integrity: sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  js-cookie@3.0.7:
+    resolution: {integrity: sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==}
+    engines: {node: '>=20'}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -409,8 +522,19 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
@@ -420,11 +544,27 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nopt@7.2.1:
+    resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    hasBin: true
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -440,13 +580,33 @@ packages:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  proto-list@1.2.4:
+    resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
+
   rolldown@1.0.1:
     resolution: {integrity: sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -457,6 +617,22 @@ packages:
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -568,6 +744,9 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
+  vue-component-type-helpers@3.3.0:
+    resolution: {integrity: sha512-vwR8DDsBysI9NWXa0okPFpCcW+BUC3sPTuLBNo1faMzw4QWMFd+3/lFYFu29ZN0q+8UReXWJHEYesC9dcXYCLg==}
+
   vue-tsc@3.3.0:
     resolution: {integrity: sha512-kY8RcoTOENASi0P1GLPvJgA2+hoGF+t8We1UGgmnAb1r/GjTUMSE3zz+WGfjPORZNnBHdAt67sVPhBLXWunkeg==}
     hasBin: true
@@ -590,10 +769,23 @@ packages:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
 
 snapshots:
 
@@ -626,6 +818,15 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
@@ -635,7 +836,12 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
+  '@one-ini/wasm@0.1.1': {}
+
   '@oxc-project/types@0.130.0': {}
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@rolldown/binding-android-arm64@1.0.1':
     optional: true
@@ -827,22 +1033,81 @@ snapshots:
 
   '@vue/shared@3.5.34': {}
 
+  '@vue/test-utils@2.4.10(@vue/compiler-dom@3.5.34)(@vue/server-renderer@3.5.34(vue@3.5.34(typescript@6.0.3)))(vue@3.5.34(typescript@6.0.3))':
+    dependencies:
+      '@vue/compiler-dom': 3.5.34
+      js-beautify: 1.15.4
+      vue: 3.5.34(typescript@6.0.3)
+      vue-component-type-helpers: 3.3.0
+    optionalDependencies:
+      '@vue/server-renderer': 3.5.34(vue@3.5.34(typescript@6.0.3))
+
   '@vue/tsconfig@0.8.1(typescript@6.0.3)(vue@3.5.34(typescript@6.0.3))':
     optionalDependencies:
       typescript: 6.0.3
       vue: 3.5.34(typescript@6.0.3)
 
+  abbrev@2.0.0: {}
+
   alien-signals@3.2.1: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
 
   assertion-error@2.0.1: {}
 
+  balanced-match@1.0.2: {}
+
+  brace-expansion@2.1.0:
+    dependencies:
+      balanced-match: 1.0.2
+
   chai@6.2.2: {}
 
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  commander@10.0.1: {}
+
+  config-chain@1.1.13:
+    dependencies:
+      ini: 1.3.8
+      proto-list: 1.2.4
+
   convert-source-map@2.0.0: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   csstype@3.2.3: {}
 
   detect-libc@2.1.2: {}
+
+  eastasianwidth@0.2.0: {}
+
+  editorconfig@1.0.7:
+    dependencies:
+      '@one-ini/wasm': 0.1.1
+      commander: 10.0.1
+      minimatch: 9.0.9
+      semver: 7.8.0
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   entities@4.5.0: {}
 
@@ -862,14 +1127,50 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   fsevents@2.3.3:
     optional: true
+
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
 
   happy-dom@15.11.7:
     dependencies:
       entities: 4.5.0
       webidl-conversions: 7.0.0
       whatwg-mimetype: 3.0.0
+
+  ini@1.3.8: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  isexe@2.0.0: {}
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
+  js-beautify@1.15.4:
+    dependencies:
+      config-chain: 1.1.13
+      editorconfig: 1.0.7
+      glob: 10.5.0
+      js-cookie: 3.0.7
+      nopt: 7.2.1
+
+  js-cookie@3.0.7: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -920,17 +1221,38 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lru-cache@10.4.3: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.0
+
+  minipass@7.1.3: {}
 
   muggle-string@0.4.1: {}
 
   nanoid@3.3.12: {}
 
+  nopt@7.2.1:
+    dependencies:
+      abbrev: 2.0.0
+
   obug@2.1.1: {}
 
+  package-json-from-dist@1.0.1: {}
+
   path-browserify@1.0.1: {}
+
+  path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   pathe@2.0.3: {}
 
@@ -943,6 +1265,8 @@ snapshots:
       nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  proto-list@1.2.4: {}
 
   rolldown@1.0.1:
     dependencies:
@@ -965,13 +1289,43 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.1
       '@rolldown/binding-win32-x64-msvc': 1.0.1
 
+  semver@7.8.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
 
   source-map-js@1.2.1: {}
 
   stackback@0.0.2: {}
 
   std-env@4.1.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   tinybench@2.9.0: {}
 
@@ -1028,6 +1382,8 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
+  vue-component-type-helpers@3.3.0: {}
+
   vue-tsc@3.3.0(typescript@6.0.3):
     dependencies:
       '@volar/typescript': 2.4.28
@@ -1048,7 +1404,23 @@ snapshots:
 
   whatwg-mimetype@3.0.0: {}
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0

--- a/frontend/src/MaintenanceView.test.ts
+++ b/frontend/src/MaintenanceView.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi, beforeAll } from "vitest"
+import { nextTick } from "vue"
+import { mount } from "@vue/test-utils"
+import MaintenanceView from "./components/MaintenanceView.vue"
+
+// Stub the api module so we control the wire data.
+vi.mock("./api", () => ({
+  api: {
+    maintWatched: () => Promise.resolve({ items: [] }),
+    maintHanging: () => Promise.resolve({ items: [] }),
+    maintPending: () => Promise.resolve({
+      items: [
+        {
+          sync_sub: "movies",
+          folder: "Synclet Ship Test Movie (2099) {tmdb-0}",
+          title: "Synclet Ship Test Movie (2099)",
+          kind: "movie",
+          lib: null,
+          rating_key: null,
+          already_watched_in_plex: false,
+        },
+        {
+          sync_sub: "tv",
+          folder: "Synclet Ship Test Show (2099) {tvdb-0}",
+          title: "Synclet Ship Test Show (2099)",
+          kind: "show",
+          lib: null,
+          rating_key: null,
+          seasons: [
+            {
+              season: 1,
+              episodes: [
+                { season: 1, episode: 1, already_watched_in_plex: true, episode_rating_key: null, title: "" },
+                { season: 1, episode: 2, already_watched_in_plex: false, episode_rating_key: null, title: "" },
+              ],
+            },
+          ],
+        },
+      ],
+    }),
+    maintResolve: vi.fn(),
+  },
+}))
+
+describe("MaintenanceView pending pane visual artifact", () => {
+  it("renders the new pending-deletions pane with movie and show groups", async () => {
+    const wrapper = mount(MaintenanceView)
+    // Wait for onMounted + Promise resolution + reactivity flush
+    await new Promise(r => setTimeout(r, 50))
+    await nextTick()
+    await nextTick()
+
+    const html = wrapper.html()
+
+    expect(html).toContain("Deleted, awaiting Plex sync")
+    expect(html).toContain("Synclet Ship Test Movie")
+    expect(html).toContain("Synclet Ship Test Show")
+    expect(html).toContain("Mark all watched")
+    expect(html).toContain("Reject all")
+    expect(html).toContain("Mark watched")
+    expect(html).toContain("Reject")
+    expect(html).toContain('data-testid="pending-deletions"')
+  })
+})

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,6 +1,10 @@
 import type {
   HangingFile,
   Job,
+  PendingGroup,
+  PendingItemRef,
+  ResolveAction,
+  ResolveResponse,
   ResolveResult,
   StateBundle,
   SyncedEntry,
@@ -49,6 +53,12 @@ export const api = {
     json<{ removed: number; bytes_freed: number }>(`/api/maintenance/remove`, {
       method: "POST",
       body: JSON.stringify({ paths }),
+    }),
+  maintPending: () => json<{ items: PendingGroup[] }>(`/api/maintenance/pending`),
+  maintResolve: (items: PendingItemRef[], action: ResolveAction) =>
+    json<ResolveResponse>(`/api/maintenance/resolve`, {
+      method: "POST",
+      body: JSON.stringify({ items, action }),
     }),
 
   resolve: (url: string) =>

--- a/frontend/src/components/MaintenanceView.vue
+++ b/frontend/src/components/MaintenanceView.vue
@@ -1,22 +1,40 @@
 <script setup lang="ts">
-import { onMounted, ref } from "vue"
+import { computed, onMounted, ref } from "vue"
 import { api } from "../api"
-import type { HangingFile, WatchedFiles } from "../types"
+import type {
+  HangingFile,
+  PendingEpisode,
+  PendingGroup,
+  PendingItemRef,
+  ResolveAction,
+  ResolveItemResult,
+  WatchedFiles,
+} from "../types"
 import { humanSize, loadState, pushToast } from "../store"
 
 const watched = ref<WatchedFiles[]>([])
 const hanging = ref<HangingFile[]>([])
+const pending = ref<PendingGroup[]>([])
 const loading = ref(true)
 const error = ref("")
 const removing = ref(false)
+const resolving = ref(false)
+// Tracks which show / season cards are expanded. Keys: `${folder}` for shows,
+// `${folder}|${season}` for seasons.
+const expanded = ref<Set<string>>(new Set())
 
 async function load(): Promise<void> {
   loading.value = true
   error.value = ""
   try {
-    const [w, h] = await Promise.all([api.maintWatched(), api.maintHanging()])
+    const [w, h, p] = await Promise.all([
+      api.maintWatched(),
+      api.maintHanging(),
+      api.maintPending(),
+    ])
     watched.value = w.items
     hanging.value = h.items
+    pending.value = p.items
   } catch (e) {
     error.value = (e as Error).message
   } finally {
@@ -25,6 +43,107 @@ async function load(): Promise<void> {
 }
 
 onMounted(load)
+
+function toggleShow(folder: string): void {
+  if (expanded.value.has(folder)) {
+    expanded.value.delete(folder)
+  } else {
+    expanded.value.add(folder)
+  }
+  // reactive Set: reassign to trigger re-render
+  expanded.value = new Set(expanded.value)
+}
+
+function toggleSeason(folder: string, season: number): void {
+  const key = `${folder}|${season}`
+  if (expanded.value.has(key)) {
+    expanded.value.delete(key)
+  } else {
+    expanded.value.add(key)
+  }
+  expanded.value = new Set(expanded.value)
+}
+
+function totalEpisodes(g: PendingGroup): number {
+  return (g.seasons ?? []).reduce((n, s) => n + s.episodes.length, 0)
+}
+
+function refsForGroup(g: PendingGroup): PendingItemRef[] {
+  if (g.kind === "movie") {
+    return [{ sync_sub: g.sync_sub, folder: g.folder }]
+  }
+  return (g.seasons ?? []).flatMap(s =>
+    s.episodes.map(e => ({
+      sync_sub: g.sync_sub,
+      folder: g.folder,
+      season: e.season,
+      episode: e.episode,
+    }))
+  )
+}
+
+function refsForSeason(g: PendingGroup, season: number): PendingItemRef[] {
+  const s = (g.seasons ?? []).find(s => s.season === season)
+  if (!s) return []
+  return s.episodes.map(e => ({
+    sync_sub: g.sync_sub,
+    folder: g.folder,
+    season: e.season,
+    episode: e.episode,
+  }))
+}
+
+function refForEpisode(g: PendingGroup, ep: PendingEpisode): PendingItemRef {
+  return { sync_sub: g.sync_sub, folder: g.folder, season: ep.season, episode: ep.episode }
+}
+
+function summarizeResolve(results: ResolveItemResult[]): string {
+  const counts = { ok: 0, scrobble_failed: 0, no_rating_key: 0, rejected: 0 }
+  for (const r of results) counts[r.status] += 1
+  const parts: string[] = []
+  if (counts.ok) parts.push(`${counts.ok} scrobbled`)
+  if (counts.rejected) parts.push(`${counts.rejected} rejected`)
+  if (counts.scrobble_failed) parts.push(`${counts.scrobble_failed} scrobble failed`)
+  if (counts.no_rating_key) parts.push(`${counts.no_rating_key} not found in Plex`)
+  return parts.join(", ") || "no items"
+}
+
+async function resolveItems(
+  items: PendingItemRef[],
+  action: ResolveAction,
+  label: string,
+): Promise<void> {
+  if (items.length === 0) return
+  const verb = action === "confirm" ? "Mark watched" : "Reject"
+  if (!confirm(`${verb} ${items.length} item${items.length === 1 ? "" : "s"}?\n\n${label}`)) {
+    return
+  }
+  resolving.value = true
+  try {
+    const res = await api.maintResolve(items, action)
+    if (res.error) {
+      pushToast({ kind: "error", text: res.error })
+    } else {
+      const anyFailed = res.results.some(
+        r => r.status === "scrobble_failed" || r.status === "no_rating_key"
+      )
+      pushToast({
+        kind: anyFailed ? "error" : "success",
+        text: `${verb}: ${summarizeResolve(res.results)}`,
+      })
+    }
+    await load()
+    await loadState(true)
+  } catch (e) {
+    pushToast({ kind: "error", text: (e as Error).message })
+  } finally {
+    resolving.value = false
+  }
+}
+
+const totalPendingEpisodes = computed(() =>
+  pending.value.reduce((n, g) => n + (g.kind === "movie" ? 1 : totalEpisodes(g)), 0)
+)
 
 async function removePaths(paths: string[], label: string): Promise<void> {
   if (paths.length === 0) return
@@ -94,6 +213,143 @@ function totalHangingBytes(): number {
         </ul>
       </section>
 
+      <section class="panel" data-testid="pending-deletions">
+        <header>
+          <h2>Deleted, awaiting Plex sync</h2>
+          <span class="dim">
+            {{ pending.length }} title{{ pending.length === 1 ? "" : "s" }}
+            <template v-if="totalPendingEpisodes !== pending.length">
+              · {{ totalPendingEpisodes }} item{{ totalPendingEpisodes === 1 ? "" : "s" }}
+            </template>
+          </span>
+        </header>
+        <p v-if="pending.length === 0" class="empty">
+          No pending deletions. Synced media matches the snapshot.
+        </p>
+        <ul v-else class="pending-list">
+          <li v-for="g in pending" :key="g.sync_sub + '/' + g.folder" class="group">
+            <!-- Movie: single row, no nesting -->
+            <template v-if="g.kind === 'movie'">
+              <div class="row movie">
+                <span class="name">{{ g.title }}</span>
+                <span v-if="g.already_watched_in_plex" class="badge dim">already watched in Plex</span>
+                <span class="lib dim">{{ g.lib ?? '—' }}</span>
+                <span class="spacer"></span>
+                <button
+                  class="primary mini"
+                  :disabled="resolving"
+                  @click="resolveItems(refsForGroup(g), 'confirm', g.title)"
+                >
+                  Mark watched
+                </button>
+                <button
+                  class="danger mini"
+                  :disabled="resolving"
+                  @click="resolveItems(refsForGroup(g), 'reject', g.title)"
+                >
+                  Reject
+                </button>
+              </div>
+            </template>
+
+            <!-- Show / YouTube: expandable header + nested seasons -->
+            <template v-else>
+              <div class="row show-header">
+                <button
+                  class="toggle"
+                  :aria-expanded="expanded.has(g.folder)"
+                  @click="toggleShow(g.folder)"
+                >
+                  <span class="caret">{{ expanded.has(g.folder) ? "▾" : "▸" }}</span>
+                  <span class="name">{{ g.title }}</span>
+                </button>
+                <span class="dim">
+                  {{ totalEpisodes(g) }} episode{{ totalEpisodes(g) === 1 ? "" : "s" }}
+                </span>
+                <span class="spacer"></span>
+                <button
+                  class="primary mini"
+                  :disabled="resolving"
+                  @click="resolveItems(refsForGroup(g), 'confirm', `${g.title} (all)`)"
+                >
+                  Mark all watched
+                </button>
+                <button
+                  class="danger mini"
+                  :disabled="resolving"
+                  @click="resolveItems(refsForGroup(g), 'reject', `${g.title} (all)`)"
+                >
+                  Reject all
+                </button>
+              </div>
+              <ul v-if="expanded.has(g.folder)" class="seasons">
+                <li v-for="s in g.seasons ?? []" :key="g.folder + '|' + s.season" class="season">
+                  <div class="row season-header">
+                    <button
+                      class="toggle"
+                      :aria-expanded="expanded.has(`${g.folder}|${s.season}`)"
+                      @click="toggleSeason(g.folder, s.season)"
+                    >
+                      <span class="caret">
+                        {{ expanded.has(`${g.folder}|${s.season}`) ? "▾" : "▸" }}
+                      </span>
+                      <span class="season-label">Season {{ s.season }}</span>
+                    </button>
+                    <span class="dim">
+                      {{ s.episodes.length }} ep{{ s.episodes.length === 1 ? "" : "s" }}
+                    </span>
+                    <span class="spacer"></span>
+                    <button
+                      class="primary mini"
+                      :disabled="resolving"
+                      @click="resolveItems(refsForSeason(g, s.season), 'confirm', `${g.title} S${s.season}`)"
+                    >
+                      Mark season watched
+                    </button>
+                    <button
+                      class="danger mini"
+                      :disabled="resolving"
+                      @click="resolveItems(refsForSeason(g, s.season), 'reject', `${g.title} S${s.season}`)"
+                    >
+                      Reject season
+                    </button>
+                  </div>
+                  <ul v-if="expanded.has(`${g.folder}|${s.season}`)" class="episodes">
+                    <li
+                      v-for="e in s.episodes"
+                      :key="`${g.folder}|${e.season}|${e.episode}`"
+                      class="row episode"
+                    >
+                      <span class="ep-code mono">
+                        S{{ String(e.season).padStart(2, "0") }}E{{ String(e.episode).padStart(2, "0") }}
+                      </span>
+                      <span v-if="e.already_watched_in_plex" class="badge dim">
+                        already watched in Plex
+                      </span>
+                      <span class="spacer"></span>
+                      <button
+                        class="primary mini"
+                        :disabled="resolving"
+                        @click="resolveItems([refForEpisode(g, e)], 'confirm', `${g.title} S${e.season}E${e.episode}`)"
+                      >
+                        Mark watched
+                      </button>
+                      <button
+                        class="danger mini"
+                        :disabled="resolving"
+                        @click="resolveItems([refForEpisode(g, e)], 'reject', `${g.title} S${e.season}E${e.episode}`)"
+                      >
+                        Reject
+                      </button>
+                    </li>
+                  </ul>
+                </li>
+              </ul>
+            </template>
+          </li>
+        </ul>
+      </section>
+
       <section class="panel">
         <header>
           <h2>Hanging files</h2>
@@ -155,4 +411,54 @@ li:last-child { border-bottom: none; }
   li { flex-wrap: wrap; }
   .name { flex: 1 1 100%; }
 }
+
+/* ── Pending-deletions pane ──────────────────────────────────────────── */
+
+.pending-list { display: flex; flex-direction: column; }
+.pending-list > li.group {
+  display: block;
+  padding: 0;
+  border-bottom: 1px solid var(--border);
+}
+.pending-list > li.group:last-child { border-bottom: none; }
+
+.row {
+  display: flex; align-items: center; gap: 0.7rem;
+  padding: 0.55rem 1rem;
+  font-size: 0.88rem;
+}
+.row.show-header { font-weight: 500; }
+.row.season-header { padding-left: 2rem; background: var(--bg-elev); }
+.row.episode { padding-left: 3rem; font-size: 0.83rem; }
+
+.toggle {
+  display: inline-flex; align-items: center; gap: 0.4rem;
+  background: none; border: none; color: inherit; cursor: pointer;
+  padding: 0; font: inherit; text-align: left;
+}
+.caret { width: 0.9rem; display: inline-block; color: var(--fg-muted); }
+
+.seasons, .episodes { list-style: none; padding: 0; margin: 0; }
+.seasons > li.season { border-top: 1px solid var(--border); }
+
+.badge {
+  font-size: 0.72rem;
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+}
+
+.ep-code { font-size: 0.78rem; }
+.lib { font-size: 0.78rem; }
+.season-label { font-weight: 500; }
+
+button.primary {
+  background: var(--accent, #2563eb);
+  color: white;
+  border: 1px solid var(--accent, #2563eb);
+  border-radius: 4px;
+  cursor: pointer;
+}
+button.primary:disabled { opacity: 0.5; cursor: not-allowed; }
 </style>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -146,3 +146,57 @@ export interface ResolveResult {
 }
 
 export type Tab = "library" | "synced" | "watchlist" | "maintenance"
+
+export interface PendingEpisode {
+  season: number
+  episode: number
+  already_watched_in_plex: boolean
+  episode_rating_key: string | null
+  title: string
+}
+
+export interface PendingSeason {
+  season: number
+  episodes: PendingEpisode[]
+}
+
+export interface PendingGroup {
+  sync_sub: string
+  folder: string
+  title: string
+  kind: Kind
+  lib: string | null
+  rating_key: string | null
+  // movie-only:
+  already_watched_in_plex?: boolean
+  // show / youtube only:
+  seasons?: PendingSeason[]
+}
+
+export interface PendingItemRef {
+  sync_sub: string
+  folder: string
+  season?: number | null
+  episode?: number | null
+}
+
+export type ResolveAction = "confirm" | "reject"
+
+export type ResolveStatus =
+  | "ok"
+  | "scrobble_failed"
+  | "no_rating_key"
+  | "rejected"
+
+export interface ResolveItemResult {
+  sync_sub: string
+  folder: string
+  season: number | null
+  episode: number | null
+  status: ResolveStatus
+}
+
+export interface ResolveResponse {
+  results: ResolveItemResult[]
+  error?: string
+}


### PR DESCRIPTION
## Summary

Implements the deletion-driven watch-state write-back flow locked in #7:
when a synced file disappears from `SYNC_ROOT`, MaintenanceView surfaces it
as pending and the user confirms (scrobble to Plex + drop from snapshot) or
rejects (drop only). Single source of truth is `snapshot.json` under
`/app/data`; pending = snapshot - on-disk.

## Architecture (locked in #7 design comment)

- Plex HTTP scrobble, not the watchstate DB. The `:ro` mount on
  `/appdata/watchstate` is preserved because the WatchState daemon owns
  the writers (see `synclet/watchstate.py:20-28` `immutable=1` comment).
- Frontend-triggered scan, no FS watcher. Matches the existing pull-based
  architecture with a 30s state TTL.
- Episode-level ratingKey resolved via
  `/library/metadata/{showRK}/allLeaves` — surfaced by live testing that
  the show ratingKey is NOT the correct scrobble target for an episode.

## Files

Backend: `synclet/pending.py` (new), hooks in `synclet/sync_ops.py`,
`scrobble` + `episode_rating_keys` in `synclet/plex.py`, `SNAPSHOT_FILE`
in `synclet/config.py`, two new routes in `main.py`. `_find_source_lib`
renamed to `find_source_lib` (it was already being imported across module
boundary from `main.py`, so the underscore convention was already broken).

Frontend: 5 new types in `types.ts`, `maintPending`/`maintResolve` in
`api.ts`, new collapsible "Deleted, awaiting Plex sync" pane in
`MaintenanceView.vue` with show → season → episode tree and per-level
confirm/reject affordances.

Tests: 28 new tests including wire-contract assertions that name the
frontend dependency (matching the existing pattern for `/api/state`),
plus a `vue-test-utils` mount of `MaintenanceView` that asserts the new
pane renders correctly.

## Live verification (against the running stack)

1. `GET /api/maintenance/pending` after bootstrap returned `items=0` — the
   snapshot was initialised from current disk state, no false positives.
2. Injected ghost movie + ghost show into `snapshot.json` via
   `docker exec`. `GET /api/maintenance/pending` returned the correct
   grouped shape (movie has no `seasons` key; show has `seasons[]` with
   nested `episodes[]`).
3. `POST /api/maintenance/resolve` with `action=reject`: per-item status
   `"rejected"`, snapshot cleaned, subsequent `GET` returned `items=0`.
4. `plex.scrobble("241679")` against the real Plex server at
   `192.168.86.183:32400`: `viewCount` went `1 -> 2`, `lastViewedAt`
   updated. Wire shape proven end-to-end.
5. `plex.episode_rating_keys("241671")` against real show: returned 8
   episodes with correct `(parentIndex, index) -> ratingKey` mapping
   (matches the show's leafCount).
6. `MaintenanceView.vue` rendered via `vue-test-utils` with mocked api:
   DOM contains the new pane header, movie row, show row, collapsible
   toggle, and all six button labels.

## Behaviour to know about

Plex scrobble is **not idempotent** — `viewCount` increments on each
call, even for items Plex already knows are watched. The "already watched
in Plex" badge is informational; confirm still scrobbles. This is the
explicit user intent ("I watched this, please record it"), so the
re-scrobble is acceptable. The badge is the signal that the user can
reject instead if they prefer not to add a play event.

## Pre-existing rot surfaced during this work

Filed separately, not addressed in this PR:

- #8: `pnpm build` fails on `main` (missing `@types/node`, TS errors in
  `DetailDrawer.vue` and `JobToasts.vue` from before this branch).
- #9: `lint.sh` fails 840 ruff errors on `main` (S101 in tests should be
  per-file-ignored; DOC201/PLC0415 conventions need a project-wide call).

The diff includes ruff-format cosmetic changes to several unrelated files
(`resolve.py`, `scan.py`, `state.py`, `watchlist.py`, three test files)
picked up when running `lint.sh` during development. They match the
configured formatter and would re-apply on the next run.

## Test plan

- [x] Backend: `cd backend && uv run pytest` — 127 pass
- [x] Backend: pyright clean on all touched files
  (`synclet/{pending,sync_ops,plex,config}.py`, `main.py`)
- [x] Frontend: `cd frontend && pnpm test` — 21 pass
- [x] Live curl `GET /api/maintenance/pending` on Tower — returns wire
  shape
- [x] Live `POST /api/maintenance/resolve` with reject — clears snapshot
- [x] Live `plex.scrobble()` against real Plex — landed
- [x] Live `plex.episode_rating_keys()` against real Plex — correct
  mapping
- [x] `MaintenanceView.vue` DOM artifact via vue-test-utils

🤖 Generated with [Claude Code](https://claude.com/claude-code)