### PR TITLE
Sweep orphan sidecars + prune empty folders after resolve (Closes #11)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -320,9 +320,17 @@ async def api_maint_resolve(data: ResolvePendingRequest) -> dict:
     Confirm scrobbles each item to Plex (best-effort, per-item) and drops it
     from the snapshot. Reject just drops from the snapshot. Per-item results
     let the UI flag scrobble failures without aborting the rest of the batch.
+
+    After resolve, orphan sidecars (subtitles, .nfo, art) and now-empty
+    parent dirs are swept by pending.cleanup_after_resolve. Counts surface
+    in the response's `cleanup` field for toast UX.
     """
     if data.action not in {"confirm", "reject"}:
-        return {"error": f"unknown action: {data.action}", "results": []}
+        return {
+            "error": f"unknown action: {data.action}",
+            "results": [],
+            "cleanup": {"removed_files": 0, "removed_dirs": 0},
+        }
     keys = [
         pending.SnapshotKey(
             sync_sub=item.sync_sub,
@@ -332,8 +340,8 @@ async def api_maint_resolve(data: ResolvePendingRequest) -> dict:
         )
         for item in data.items
     ]
-    results = pending.resolve(keys, confirm=(data.action == "confirm"))
-    return {"results": [r.to_dict() for r in results]}
+    results, cleanup = pending.resolve(keys, confirm=(data.action == "confirm"))
+    return {"results": [r.to_dict() for r in results], "cleanup": cleanup}
 
 
 @post("/api/resolve-link")

--- a/backend/synclet/pending.py
+++ b/backend/synclet/pending.py
@@ -281,6 +281,109 @@ def compute_pending() -> set[SnapshotKey]:
     return load_snapshot() - scan_on_disk()
 
 
+# ── Post-resolve filesystem cleanup ─────────────────────────────────────────
+
+
+def _prune_empty_ancestors(start: Path, stop: Path) -> int:
+    """Remove empty dirs from `start` walking upward, never crossing `stop`.
+
+    Returns the number of directories removed. Both `start` and `stop` are
+    inclusive at their respective ends: `stop` is the floor (never removed).
+    """
+    removed = 0
+    current = start
+    while current != stop and stop in current.parents:
+        try:
+            current.rmdir()
+        except OSError:
+            break
+        removed += 1
+        current = current.parent
+    return removed
+
+
+def cleanup_after_resolve(key: SnapshotKey) -> dict[str, int]:
+    """Sweep orphan sidecars + prune empty ancestor dirs for a resolved item.
+
+    Only runs when the matching video is genuinely gone. For shows this means
+    no file with the same `SxxEyy` pattern survives in the season dir; for
+    movies it means no video file of any kind remains in the title folder.
+    The presence of a video is the safety latch: it prevents stripping subs
+    off an episode that's still synced (race / hand edit / partial delete).
+
+    Returns counts so the API can surface a "removed N files, M folders" hint.
+    """
+    counts = {"removed_files": 0, "removed_dirs": 0}
+
+    sub_root = SYNC_ROOT / key.sync_sub
+    folder_path = sub_root / key.folder
+    if not folder_path.exists():
+        return counts
+
+    if key.season is None or key.episode is None:
+        # Movie: sweep when no videos remain in the title folder.
+        videos_remaining = any(
+            f.is_file() and f.suffix.lower() in VIDEO_EXTS
+            for f in folder_path.iterdir()
+        )
+        if videos_remaining:
+            return counts
+        for f in list(folder_path.iterdir()):
+            if f.is_file():
+                try:
+                    f.unlink()
+                    counts["removed_files"] += 1
+                except OSError:
+                    continue
+        # rmdir the title folder + walk up to (but not into) sub_root.
+        counts["removed_dirs"] += _prune_empty_ancestors(folder_path, sub_root)
+        return counts
+
+    # Show / youtube: match SxxEyy on filenames inside the season dir(s).
+    # Multiple season dirs with the same number are uncommon but possible
+    # (e.g. "Season 01" vs "Specials 01"); iterate all that parse to the key.
+    from synclet.scan import _season_num  # noqa: PLC0415
+
+    ep_pat = re.compile(
+        rf"[Ss]{key.season:02d}[Ee]{key.episode:02d}(?!\d)|"
+        rf"[Ss]{key.season}[Ee]{key.episode:04d}(?!\d)",
+        re.IGNORECASE,
+    )
+    season_dirs = [
+        d
+        for d in folder_path.iterdir()
+        if d.is_dir() and _season_num(d) == key.season
+    ]
+    for season_dir in season_dirs:
+        matching = [f for f in season_dir.iterdir() if ep_pat.search(f.name)]
+        videos_remaining = any(
+            f.suffix.lower() in VIDEO_EXTS for f in matching
+        )
+        if videos_remaining:
+            continue
+        for f in matching:
+            if f.is_file():
+                try:
+                    f.unlink()
+                    counts["removed_files"] += 1
+                except OSError:
+                    continue
+        # If the season dir is now empty, rmdir it and walk up the show folder.
+        if not any(season_dir.iterdir()):
+            counts["removed_dirs"] += _prune_empty_ancestors(season_dir, sub_root)
+    return counts
+
+
+def aggregate_cleanup(keys: Iterable[SnapshotKey]) -> dict[str, int]:
+    """Run cleanup_after_resolve over a batch and sum the counts."""
+    total = {"removed_files": 0, "removed_dirs": 0}
+    for k in keys:
+        c = cleanup_after_resolve(k)
+        total["removed_files"] += c["removed_files"]
+        total["removed_dirs"] += c["removed_dirs"]
+    return total
+
+
 # ── Grouping for the API response ───────────────────────────────────────────
 
 
@@ -417,8 +520,10 @@ class ResolveResult:
         return d
 
 
-def resolve(keys: Iterable[SnapshotKey], *, confirm: bool) -> list[ResolveResult]:
-    """Resolve a batch of pending keys.
+def resolve(
+    keys: Iterable[SnapshotKey], *, confirm: bool,
+) -> tuple[list[ResolveResult], dict[str, int]]:
+    """Resolve a batch of pending keys, sweep filesystem leftovers.
 
     On reject: every key is dropped from the snapshot, returns status
     "rejected" per key. On confirm: each key is scrobbled to Plex first
@@ -426,6 +531,14 @@ def resolve(keys: Iterable[SnapshotKey], *, confirm: bool) -> list[ResolveResult
     get "scrobble_failed" or "no_rating_key". The snapshot drops every key
     regardless of scrobble outcome — the user already deleted the file, so
     putting it back in pending would be incorrect.
+
+    After the snapshot mutation, runs cleanup_after_resolve for each key to
+    sweep orphan subtitle sidecars and prune empty parent dirs. Cleanup is
+    safe to run for both confirm and reject because the trigger is "this
+    item is gone from disk now," not "the user wants Plex to know."
+
+    Returns (results, cleanup_totals). cleanup_totals has the shape
+    {"removed_files": N, "removed_dirs": M} aggregated across the batch.
     """
     # Local imports keep the module's import graph small.
     from synclet.plex import (  # noqa: PLC0415
@@ -441,7 +554,8 @@ def resolve(keys: Iterable[SnapshotKey], *, confirm: bool) -> list[ResolveResult
     if not confirm:
         results.extend(ResolveResult(key=k, status="rejected") for k in keys)
         remove_keys(keys)
-        return results
+        cleanup = aggregate_cleanup(keys)
+        return results, cleanup
 
     for k in keys:
         lib = find_source_lib(k.folder)
@@ -466,4 +580,5 @@ def resolve(keys: Iterable[SnapshotKey], *, confirm: bool) -> list[ResolveResult
             results.append(ResolveResult(key=k, status="scrobble_failed"))
 
     remove_keys(keys)
-    return results
+    cleanup = aggregate_cleanup(keys)
+    return results, cleanup

--- a/backend/synclet/sync_ops.py
+++ b/backend/synclet/sync_ops.py
@@ -388,7 +388,6 @@ def remove_files(paths: list[str]) -> dict:
 
     removed = 0
     bytes_freed = 0
-    parents: set[Path] = set()
     for p in paths:
         path = Path(p)
         if path.exists() and path.is_file():
@@ -397,19 +396,20 @@ def remove_files(paths: list[str]) -> dict:
                 path.unlink()
                 removed += 1
                 bytes_freed += size
-                parents.add(path.parent)
-                parents.add(path.parent.parent)
             except OSError:
                 continue
-    # Prune empty dirs
-    for parent in sorted(parents, key=lambda x: -len(x.parts)):
-        try:
-            parent.rmdir()
-        except OSError:
-            pass
     state_mod.invalidate()
     # Implicit confirm: the maintenance "remove watched" path means the user
     # already watched these in Plex. Drop them from the snapshot so they do
     # NOT later appear as pending deletions.
     pending_mod.remove_keys(keys_removing)
-    return {"removed": removed, "bytes_freed": bytes_freed}
+    # Sweep orphan sidecars + prune empty parent dirs via the shared cleanup
+    # helper (same logic that runs after explicit resolve). This subsumes
+    # the prior parent.rmdir() loop and additionally clears subtitle/.nfo
+    # leftovers the user did not explicitly select.
+    cleanup = pending_mod.aggregate_cleanup(keys_removing)
+    return {
+        "removed": removed,
+        "bytes_freed": bytes_freed,
+        "cleanup": cleanup,
+    }

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -234,6 +234,9 @@ class TestMaintenanceResolveRoute:
         assert r.status_code == 201
         body = r.json()
         assert body["results"][0]["status"] == "rejected"
+        # Cleanup summary is always present so the frontend toast can show it.
+        assert "cleanup" in body
+        assert body["cleanup"].keys() == {"removed_files", "removed_dirs"}
         assert load_snapshot() == set()
 
     def test_confirm_calls_scrobble_and_returns_per_item_status(

--- a/backend/tests/test_pending.py
+++ b/backend/tests/test_pending.py
@@ -17,6 +17,7 @@ from synclet.pending import (
     SnapshotKey,
     add_keys,
     bootstrap_if_missing,
+    cleanup_after_resolve,
     compute_pending,
     keys_for_paths,
     load_snapshot,
@@ -252,7 +253,7 @@ class TestResolveReject:
 
         k = SnapshotKey(sync_sub="tv", folder="X", season=1, episode=1)
         save_snapshot({k})
-        results = resolve([k], confirm=False)
+        results, _cleanup = resolve([k], confirm=False)
         assert [r.status for r in results] == ["rejected"]
         assert load_snapshot() == set()
 
@@ -280,7 +281,7 @@ class TestResolveConfirm:
         k = SnapshotKey(sync_sub="movies", folder="Movie X")
         save_snapshot({k})
 
-        results = resolve([k], confirm=True)
+        results, _cleanup = resolve([k], confirm=True)
         assert [r.status for r in results] == ["ok"]
         assert called == ["9000"]
         assert load_snapshot() == set()
@@ -300,7 +301,7 @@ class TestResolveConfirm:
         k = SnapshotKey(sync_sub="movies", folder="Movie X")
         save_snapshot({k})
 
-        results = resolve([k], confirm=True)
+        results, _cleanup = resolve([k], confirm=True)
         assert [r.status for r in results] == ["scrobble_failed"]
         assert load_snapshot() == set()
 
@@ -335,7 +336,7 @@ class TestResolveConfirm:
         k = SnapshotKey(sync_sub="tv", folder="Ghost Show", season=1, episode=3)
         save_snapshot({k})
 
-        results = resolve([k], confirm=True)
+        results, _cleanup = resolve([k], confirm=True)
         assert [r.status for r in results] == ["ok"]
         # Must be the EPISODE ratingKey, not the show's. This is the trap the
         # initial design comment got wrong before live-testing surfaced it.
@@ -355,7 +356,7 @@ class TestResolveConfirm:
         k = SnapshotKey(sync_sub="movies", folder="Movie X")
         save_snapshot({k})
 
-        results = resolve([k], confirm=True)
+        results, _cleanup = resolve([k], confirm=True)
         assert [r.status for r in results] == ["no_rating_key"]
         # Snapshot still cleared — the file is gone, leaving it in pending
         # would re-prompt the user every page load.
@@ -403,3 +404,155 @@ class TestGroupedPending:
         assert s_nums == [1, 2]
         assert len(seasons[0]["episodes"]) == 2
         assert len(seasons[1]["episodes"]) == 1
+
+
+# ── cleanup_after_resolve ────────────────────────────────────────────────────
+
+
+class TestCleanupAfterResolveMovie:
+    def test_sweeps_sidecars_and_folder_when_video_is_gone(
+        self, patch_snapshot, patch_paths
+    ):
+        sync = patch_paths["sync"]
+        folder = sync / "movies" / "Ghost Movie (2099)"
+        folder.mkdir(parents=True)
+        # Sidecars only. No video — the user deleted that already.
+        (folder / "Ghost Movie.en.srt").write_text("subs")
+        (folder / "movie.nfo").write_text("nfo")
+        (folder / "poster.jpg").write_bytes(b"\xff")
+
+        counts = cleanup_after_resolve(
+            SnapshotKey(sync_sub="movies", folder="Ghost Movie (2099)")
+        )
+        assert counts == {"removed_files": 3, "removed_dirs": 1}
+        assert not folder.exists()
+
+    def test_no_op_when_video_still_present(self, patch_snapshot, patch_paths):
+        """Safety latch: don't strip sidecars from a movie still on disk."""
+        sync = patch_paths["sync"]
+        folder = sync / "movies" / "Ghost Movie (2099)"
+        folder.mkdir(parents=True)
+        (folder / "Ghost Movie.mkv").write_bytes(b"\0" * 10)
+        (folder / "Ghost Movie.en.srt").write_text("subs")
+
+        counts = cleanup_after_resolve(
+            SnapshotKey(sync_sub="movies", folder="Ghost Movie (2099)")
+        )
+        assert counts == {"removed_files": 0, "removed_dirs": 0}
+        assert (folder / "Ghost Movie.mkv").exists()
+        assert (folder / "Ghost Movie.en.srt").exists()
+
+    def test_no_op_when_folder_missing(self, patch_snapshot, patch_paths):
+        counts = cleanup_after_resolve(
+            SnapshotKey(sync_sub="movies", folder="Nonexistent")
+        )
+        assert counts == {"removed_files": 0, "removed_dirs": 0}
+
+
+class TestCleanupAfterResolveShow:
+    def test_sweeps_episode_sidecars_when_video_gone(
+        self, patch_snapshot, patch_paths
+    ):
+        sync = patch_paths["sync"]
+        season = sync / "tv" / "Ghost Show (2099)" / "Season 01"
+        season.mkdir(parents=True)
+        # Only the S01E01 sidecar remains; user deleted the .mkv.
+        (season / "Ghost Show - S01E01 - X.en.srt").write_text("subs")
+        # S01E02 video is still here — must NOT touch it.
+        (season / "Ghost Show - S01E02 - Y.mkv").write_bytes(b"\0" * 5)
+        (season / "Ghost Show - S01E02 - Y.en.srt").write_text("subs2")
+
+        counts = cleanup_after_resolve(
+            SnapshotKey(
+                sync_sub="tv",
+                folder="Ghost Show (2099)",
+                season=1,
+                episode=1,
+            )
+        )
+        assert counts["removed_files"] == 1
+        # season dir is NOT empty (S01E02 still there), so no dir prune
+        assert counts["removed_dirs"] == 0
+        assert not (season / "Ghost Show - S01E01 - X.en.srt").exists()
+        assert (season / "Ghost Show - S01E02 - Y.mkv").exists()
+        assert (season / "Ghost Show - S01E02 - Y.en.srt").exists()
+
+    def test_prunes_season_dir_when_last_episode_swept(
+        self, patch_snapshot, patch_paths
+    ):
+        sync = patch_paths["sync"]
+        season = sync / "tv" / "Ghost Show (2099)" / "Season 01"
+        season.mkdir(parents=True)
+        (season / "Ghost Show - S01E01 - X.en.srt").write_text("subs")
+
+        counts = cleanup_after_resolve(
+            SnapshotKey(
+                sync_sub="tv",
+                folder="Ghost Show (2099)",
+                season=1,
+                episode=1,
+            )
+        )
+        assert counts["removed_files"] == 1
+        # Season dir empty -> rmdir; show folder also empty -> rmdir (2 dirs)
+        assert counts["removed_dirs"] == 2
+        assert not season.exists()
+        assert not season.parent.exists()
+        # Sub root must NOT be pruned (it's a stable mount point).
+        assert (sync / "tv").exists()
+
+    def test_no_op_when_video_for_episode_present(
+        self, patch_snapshot, patch_paths
+    ):
+        """Safety latch: don't strip sidecars when the video is still there."""
+        sync = patch_paths["sync"]
+        season = sync / "tv" / "Ghost Show (2099)" / "Season 01"
+        season.mkdir(parents=True)
+        (season / "Ghost Show - S01E01 - X.mkv").write_bytes(b"\0" * 5)
+        (season / "Ghost Show - S01E01 - X.en.srt").write_text("subs")
+
+        counts = cleanup_after_resolve(
+            SnapshotKey(
+                sync_sub="tv",
+                folder="Ghost Show (2099)",
+                season=1,
+                episode=1,
+            )
+        )
+        assert counts == {"removed_files": 0, "removed_dirs": 0}
+        assert (season / "Ghost Show - S01E01 - X.mkv").exists()
+
+
+class TestResolveIntegratesCleanup:
+    def test_resolve_returns_aggregated_cleanup_counts(
+        self, patch_snapshot, patch_paths, monkeypatch
+    ):
+        """resolve() runs cleanup_after_resolve for each key in the batch."""
+        sync = patch_paths["sync"]
+        # Two movies' worth of orphan sidecars.
+        m1 = sync / "movies" / "M One"
+        m2 = sync / "movies" / "M Two"
+        m1.mkdir(parents=True)
+        m2.mkdir(parents=True)
+        (m1 / "a.srt").write_text("x")
+        (m2 / "b.srt").write_text("y")
+        (m2 / "c.nfo").write_text("z")
+
+        save_snapshot(
+            {
+                SnapshotKey(sync_sub="movies", folder="M One"),
+                SnapshotKey(sync_sub="movies", folder="M Two"),
+            }
+        )
+        # Reject path keeps the test cheap (no scrobble mock needed).
+        results, cleanup = resolve(
+            [
+                SnapshotKey(sync_sub="movies", folder="M One"),
+                SnapshotKey(sync_sub="movies", folder="M Two"),
+            ],
+            confirm=False,
+        )
+        assert len(results) == 2
+        assert cleanup == {"removed_files": 3, "removed_dirs": 2}
+        assert not m1.exists()
+        assert not m2.exists()

--- a/backend/tests/test_sync_ops.py
+++ b/backend/tests/test_sync_ops.py
@@ -315,3 +315,33 @@ class TestSyncOpsSnapshotIntegration:
         r = remove_files([str(target)])
         assert r["removed"] == 1
         assert key not in load_snapshot()
+        # cleanup is part of the wire shape; frontend toast surfaces totals.
+        assert "cleanup" in r
+        assert r["cleanup"].keys() == {"removed_files", "removed_dirs"}
+
+    def test_remove_files_sweeps_sibling_sidecars(self, patch_paths):
+        """Removing the .mkv via maintenance should also clear the .srt next
+        to it AND the now-empty Season / show parent dirs."""
+        from synclet.pending import SnapshotKey, save_snapshot
+
+        sync = patch_paths["sync"]
+        season = sync / "tv" / "Sweep Show" / "Season 01"
+        season.mkdir(parents=True)
+        mkv = season / "Sweep Show - S01E01 - Pilot.mkv"
+        srt = season / "Sweep Show - S01E01 - Pilot.en.srt"
+        mkv.write_bytes(b"\0" * 5)
+        srt.write_text("subs")
+        save_snapshot(
+            {SnapshotKey(sync_sub="tv", folder="Sweep Show", season=1, episode=1)}
+        )
+
+        r = remove_files([str(mkv)])
+        assert r["removed"] == 1
+        # cleanup swept the .srt sibling + pruned the empty Season + show dirs.
+        assert r["cleanup"]["removed_files"] == 1
+        assert r["cleanup"]["removed_dirs"] == 2
+        assert not srt.exists()
+        assert not season.exists()
+        assert not season.parent.exists()
+        # sync sub root must remain (it's the mount point).
+        assert (sync / "tv").exists()

--- a/frontend/src/MaintenanceView.test.ts
+++ b/frontend/src/MaintenanceView.test.ts
@@ -38,7 +38,10 @@ vi.mock("./api", () => ({
         },
       ],
     }),
-    maintResolve: vi.fn(),
+    maintResolve: vi.fn().mockResolvedValue({
+      results: [],
+      cleanup: { removed_files: 0, removed_dirs: 0 },
+    }),
   },
 }))
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -3,6 +3,7 @@ import type {
   Job,
   PendingGroup,
   PendingItemRef,
+  RemoveResponse,
   ResolveAction,
   ResolveResponse,
   ResolveResult,
@@ -50,7 +51,7 @@ export const api = {
   maintWatched: () => json<{ items: WatchedFiles[] }>(`/api/maintenance/watched`),
   maintHanging: () => json<{ items: HangingFile[] }>(`/api/maintenance/hanging`),
   maintRemove: (paths: string[]) =>
-    json<{ removed: number; bytes_freed: number }>(`/api/maintenance/remove`, {
+    json<RemoveResponse>(`/api/maintenance/remove`, {
       method: "POST",
       body: JSON.stringify({ paths }),
     }),

--- a/frontend/src/components/MaintenanceView.vue
+++ b/frontend/src/components/MaintenanceView.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted, ref } from "vue"
 import { api } from "../api"
 import type {
+  CleanupSummary,
   HangingFile,
   PendingEpisode,
   PendingGroup,
@@ -108,6 +109,14 @@ function summarizeResolve(results: ResolveItemResult[]): string {
   return parts.join(", ") || "no items"
 }
 
+function summarizeCleanup(c: CleanupSummary | undefined): string {
+  if (!c || (c.removed_files === 0 && c.removed_dirs === 0)) return ""
+  const parts: string[] = []
+  if (c.removed_files) parts.push(`${c.removed_files} sidecar${c.removed_files === 1 ? "" : "s"}`)
+  if (c.removed_dirs) parts.push(`${c.removed_dirs} folder${c.removed_dirs === 1 ? "" : "s"}`)
+  return ` (cleaned ${parts.join(", ")})`
+}
+
 async function resolveItems(
   items: PendingItemRef[],
   action: ResolveAction,
@@ -129,7 +138,7 @@ async function resolveItems(
       )
       pushToast({
         kind: anyFailed ? "error" : "success",
-        text: `${verb}: ${summarizeResolve(res.results)}`,
+        text: `${verb}: ${summarizeResolve(res.results)}${summarizeCleanup(res.cleanup)}`,
       })
     }
     await load()
@@ -153,7 +162,7 @@ async function removePaths(paths: string[], label: string): Promise<void> {
     const r = await api.maintRemove(paths)
     pushToast({
       kind: "success",
-      text: `Removed ${r.removed} files (${humanSize(r.bytes_freed)})`,
+      text: `Removed ${r.removed} files (${humanSize(r.bytes_freed)})${summarizeCleanup(r.cleanup)}`,
     })
     await load()
     await loadState(true)

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -196,7 +196,19 @@ export interface ResolveItemResult {
   status: ResolveStatus
 }
 
+export interface CleanupSummary {
+  removed_files: number
+  removed_dirs: number
+}
+
 export interface ResolveResponse {
   results: ResolveItemResult[]
+  cleanup: CleanupSummary
   error?: string
+}
+
+export interface RemoveResponse {
+  removed: number
+  bytes_freed: number
+  cleanup: CleanupSummary
 }


### PR DESCRIPTION
## Summary

Closes #11. After resolve (confirm or reject), Synclet now also clears the
non-video siblings the user left behind (subtitles, .nfo, art) and walks
empty parent dirs upward to the sync_sub root. The same cleanup runs in
the existing maintenance "remove watched" path so both flows are tidied
consistently.

Safety latch: cleanup only fires when no matching video remains. For shows
that means no file with the same SxxEyy pattern survives in the season
dir; for movies, no video file of any kind remains in the title folder.

## Wire shape addition

Both `POST /api/maintenance/resolve` and `POST /api/maintenance/remove`
now return a `cleanup` field:

```json
{"removed_files": 2, "removed_dirs": 1}
```

The frontend toast appends "(cleaned 2 sidecars, 1 folder)" when cleanup
actually did something.

## Live verification

```
$ docker exec synclet-backend-1 python3 /tmp/seed-cleanup.py
seeded; folder contents:
 - subs.en.srt
 - movie.nfo

$ curl ... /api/maintenance/pending | jq '.items[]|select(.folder|contains("Cleanup Test 2"))'
{"title": "Cleanup Test 2 (2099)", ...}

$ curl ... /api/maintenance/resolve -d '{...,"action":"reject"}'
{
  "results": [{"sync_sub":"movies","folder":"Cleanup Test 2 (2099)","status":"rejected"}],
  "cleanup": {"removed_files": 2, "removed_dirs": 1}
}

$ docker exec synclet-backend-1 python3 -c "...; print(p.exists())"
folder exists: False
```

Cleaned the sidecars + pruned the empty title folder. sync_sub root
(`/data/others/synced-media/movies/`) preserved.

## Test plan

- [x] 8 new backend tests for cleanup_after_resolve and remove_files
  integration
- [x] Existing resolve() tests updated for new tuple return
- [x] Backend: 135 pytest pass
- [x] Backend: pyright clean on touched files
- [x] Frontend: 21 vitest pass (MaintenanceView render test still asserts
  the new pane structure)
- [x] Live curl + folder-sweep verification against running stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)