### PR TITLE
Fix DetailDrawer scroll cutoff for series with many episodes (Closes #13)

### DIFF
--- a/frontend/src/components/DetailDrawer.vue
+++ b/frontend/src/components/DetailDrawer.vue
@@ -412,7 +412,16 @@ const movieSynced = computed(() =>
 .drawer {
   width: 540px;
   max-width: 100vw;
+  /* dvh accounts for dynamic browser chrome (URL bar, etc.) where
+     100vh would extend the scroll region beyond the visible viewport,
+     leaving the bottom of long content unreachable. 100vh stays as the
+     fallback for browsers without dvh support. */
   height: 100vh;
+  height: 100dvh;
+  /* flex-item with overflow:auto needs min-height:0 to size against its
+     content correctly; without it, deeply-stacked content can render
+     past the scroll plane and become unreachable. */
+  min-height: 0;
   background: var(--bg);
   border-left: 1px solid var(--border);
   overflow-y: auto;


### PR DESCRIPTION
## Summary

Closes #13. \`.drawer\` was \`height: 100vh\` with \`overflow-y: auto\` inside a
flex column. On browsers where 100vh extends beyond the visible viewport
(dynamic chrome, kiosk-mode windows), the scroll region's bottom became
unreachable, leaving expanded late-numbered seasons cut off.

Fix: switch to \`height: 100dvh\` (with 100vh fallback) and add
\`min-height: 0\` so the flex column honors its overflow contract under
content pressure.

## Verification

**PENDING-USER-CONFIRMATION**. This is a CSS layout fix; vitest cannot
exercise real layout. Backend tests still pass (135) and vitest still
passes (21) — neither set covers visual rendering.

Manual repro for the user to walk:
- Open a series with >8 episodes.
- The oldest season auto-expands (existing behavior).
- Scroll down past it; subsequent season headers should be reachable.
- Click any later season's chevron to expand; every episode in that
  season should be reachable by scroll.

If the symptom persists, the next layer is to restructure: drawer as a
position:absolute box inside the backdrop, with an explicit
overflow:auto inner scroll region — removing flex-item complications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)