### PR TITLE
Explicit Mark-watched in DetailDrawer at all scopes (Closes #15)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -68,6 +68,20 @@ class ResolvePendingRequest(BaseModel):
     action: str  # "confirm" | "reject"
 
 
+class ScrobbleRequest(BaseModel):
+    """Explicit mark-watched gesture.
+
+    The file is still on disk; this is "Plex's watch state drifted, sync it
+    up." Distinct from /api/maintenance/resolve which is post-deletion.
+    """
+
+    lib: str
+    folder: str
+    scope: str  # "movie" | "series" | "season" | "episode"
+    season: int | None = None
+    episode: int | None = None
+
+
 # ── Routes ────────────────────────────────────────────────────────────────────
 
 
@@ -344,6 +358,24 @@ async def api_maint_resolve(data: ResolvePendingRequest) -> dict:
     return {"results": [r.to_dict() for r in results], "cleanup": cleanup}
 
 
+@post("/api/scrobble")
+async def api_scrobble(data: ScrobbleRequest) -> dict:
+    """Mark Plex items watched explicitly (no file deletion required).
+
+    Surfaced in DetailDrawer as Mark-watched buttons at the movie / series /
+    season / episode levels. The file stays on disk; only Plex's watch state
+    is updated. WatchState's daemon picks up the change on its next poll, so
+    Synclet's grid view will reflect the new watched state shortly after.
+    """
+    return pending.mark_watched_scope(
+        lib=data.lib,
+        folder=data.folder,
+        scope=data.scope,
+        season=data.season,
+        episode=data.episode,
+    )
+
+
 @post("/api/resolve-link")
 async def api_resolve(data: ResolveLinkRequest) -> dict:
     return resolve_url(data.url)
@@ -373,6 +405,7 @@ app = Litestar(
         api_maint_remove,
         api_maint_pending,
         api_maint_resolve,
+        api_scrobble,
         api_resolve,
         api_refresh,
     ],

--- a/backend/synclet/pending.py
+++ b/backend/synclet/pending.py
@@ -582,3 +582,118 @@ def resolve(
     remove_keys(keys)
     cleanup = aggregate_cleanup(keys)
     return results, cleanup
+
+
+# ── Explicit mark-watched (no snapshot mutation, no cleanup) ────────────────
+
+
+def mark_watched_scope(
+    lib: str,
+    folder: str,
+    scope: str,
+    season: int | None = None,
+    episode: int | None = None,
+) -> dict:
+    """Scrobble Plex for an explicit user gesture, no filesystem mutation.
+
+    Distinct from `resolve(confirm=True)`:
+    - The file is still on disk; this is "Plex's watch state drifted, sync it
+      up." The snapshot is NOT mutated, no orphan cleanup runs.
+    - Scope determines how the lib/folder pair expands to individual scrobble
+      targets:
+        "movie"   -> scrobble the movie's ratingKey
+        "episode" -> scrobble (season, episode)
+        "season"  -> scrobble every episode where parentIndex == season
+        "series"  -> scrobble every episode in the show
+
+    Returns {"scrobbled": N, "failed": N, "results": [...]} where each result
+    has the per-item scrobble status. A no_rating_key result means Plex's
+    library doesn't have the item (folder mismatch or library scanning).
+    """
+    from synclet.plex import (  # noqa: PLC0415
+        episode_rating_keys,
+        find_in_library,
+        scrobble,
+    )
+
+    if scope not in {"movie", "series", "season", "episode"}:
+        return {
+            "scrobbled": 0,
+            "failed": 0,
+            "results": [],
+            "error": f"unknown scope: {scope}",
+        }
+
+    meta = find_in_library(lib, folder)
+    show_or_movie_rk = meta["ratingKey"] if meta else None
+    if not show_or_movie_rk:
+        return {
+            "scrobbled": 0,
+            "failed": 1 if scope == "movie" else 0,
+            "results": [
+                {
+                    "season": season,
+                    "episode": episode,
+                    "status": "no_rating_key",
+                },
+            ]
+            if scope == "movie"
+            else [],
+            "error": (
+                None
+                if scope != "movie"
+                else f"no Plex item for {lib}/{folder}"
+            ),
+        }
+
+    targets: list[tuple[str, int | None, int | None]] = []
+    if scope == "movie":
+        targets.append((show_or_movie_rk, None, None))
+    else:
+        ep_map = episode_rating_keys(show_or_movie_rk)
+        if scope == "episode":
+            if season is None or episode is None:
+                return {
+                    "scrobbled": 0,
+                    "failed": 0,
+                    "results": [],
+                    "error": "season and episode required for scope=episode",
+                }
+            rk = ep_map.get((season, episode))
+            if rk is None:
+                return {
+                    "scrobbled": 0,
+                    "failed": 1,
+                    "results": [
+                        {"season": season, "episode": episode, "status": "no_rating_key"},
+                    ],
+                }
+            targets.append((rk, season, episode))
+        elif scope == "season":
+            if season is None:
+                return {
+                    "scrobbled": 0,
+                    "failed": 0,
+                    "results": [],
+                    "error": "season required for scope=season",
+                }
+            for (s, e), rk in sorted(ep_map.items()):
+                if s == season:
+                    targets.append((rk, s, e))
+        else:  # series
+            for (s, e), rk in sorted(ep_map.items()):
+                targets.append((rk, s, e))
+
+    results: list[dict] = []
+    scrobbled = 0
+    failed = 0
+    for rk, s, e in targets:
+        ok = scrobble(rk)
+        results.append(
+            {"season": s, "episode": e, "status": "ok" if ok else "scrobble_failed"},
+        )
+        if ok:
+            scrobbled += 1
+        else:
+            failed += 1
+    return {"scrobbled": scrobbled, "failed": failed, "results": results}

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -283,6 +283,62 @@ class TestMaintenanceResolveRoute:
         assert body["results"] == []
 
 
+class TestScrobbleRoute:
+    def test_movie_scrobble(self, client, monkeypatch):
+        called: list[str] = []
+        monkeypatch.setattr(
+            "synclet.plex.find_in_library",
+            lambda lib, folder: {"ratingKey": "M-9"} if folder == "M" else None,
+        )
+        monkeypatch.setattr(
+            "synclet.plex.scrobble",
+            lambda rk, **_: called.append(rk) or True,
+        )
+        r = client.post(
+            "/api/scrobble",
+            json={"lib": "movies", "folder": "M", "scope": "movie"},
+        )
+        assert r.status_code == 201
+        body = r.json()
+        assert body["scrobbled"] == 1
+        assert body["failed"] == 0
+        assert called == ["M-9"]
+
+    def test_episode_scrobble(self, client, monkeypatch):
+        called: list[str] = []
+        monkeypatch.setattr(
+            "synclet.plex.find_in_library",
+            lambda lib, folder: {"ratingKey": "S-1"},
+        )
+        monkeypatch.setattr(
+            "synclet.plex.episode_rating_keys",
+            lambda show_rk: {(1, 1): "E-1-1"},
+        )
+        monkeypatch.setattr(
+            "synclet.plex.scrobble",
+            lambda rk, **_: called.append(rk) or True,
+        )
+        r = client.post(
+            "/api/scrobble",
+            json={
+                "lib": "tv", "folder": "Show",
+                "scope": "episode", "season": 1, "episode": 1,
+            },
+        )
+        body = r.json()
+        assert body["scrobbled"] == 1
+        assert called == ["E-1-1"]
+
+    def test_unknown_scope_returns_error(self, client):
+        r = client.post(
+            "/api/scrobble",
+            json={"lib": "movies", "folder": "X", "scope": "bogus"},
+        )
+        body = r.json()
+        assert "error" in body
+        assert body["scrobbled"] == 0
+
+
 class TestResolveRoute:
     def test_text_match(self, client):
         r = client.post("/api/resolve-link", json={"url": "better call saul"})

--- a/backend/tests/test_pending.py
+++ b/backend/tests/test_pending.py
@@ -21,6 +21,7 @@ from synclet.pending import (
     compute_pending,
     keys_for_paths,
     load_snapshot,
+    mark_watched_scope,
     path_to_snapshot_key,
     remove_keys,
     resolve,
@@ -556,3 +557,127 @@ class TestResolveIntegratesCleanup:
         assert cleanup == {"removed_files": 3, "removed_dirs": 2}
         assert not m1.exists()
         assert not m2.exists()
+
+
+# ── mark_watched_scope ──────────────────────────────────────────────────────
+
+
+class TestMarkWatchedScope:
+    def test_movie_scrobbles_movie_rating_key(self, monkeypatch):
+        called: list[str] = []
+        monkeypatch.setattr(
+            "synclet.plex.find_in_library",
+            lambda lib, folder: {"ratingKey": "M-300"} if folder == "Movie" else None,
+        )
+        monkeypatch.setattr(
+            "synclet.plex.scrobble",
+            lambda rk, **_: called.append(rk) or True,
+        )
+
+        r = mark_watched_scope(lib="movies", folder="Movie", scope="movie")
+        assert r["scrobbled"] == 1
+        assert r["failed"] == 0
+        assert called == ["M-300"]
+
+    def test_movie_returns_no_rating_key_when_plex_blank(self, monkeypatch):
+        monkeypatch.setattr("synclet.plex.find_in_library", lambda *a, **kw: None)
+        monkeypatch.setattr(
+            "synclet.plex.scrobble",
+            lambda *a, **kw: pytest.fail("must not call scrobble"),
+        )
+        r = mark_watched_scope(lib="movies", folder="Unknown", scope="movie")
+        assert r["scrobbled"] == 0
+        assert r["failed"] == 1
+        assert r["results"][0]["status"] == "no_rating_key"
+
+    def test_episode_scrobbles_episode_rating_key(self, monkeypatch):
+        called: list[str] = []
+        monkeypatch.setattr(
+            "synclet.plex.find_in_library",
+            lambda lib, folder: {"ratingKey": "SHOW100"} if folder == "Show" else None,
+        )
+        monkeypatch.setattr(
+            "synclet.plex.episode_rating_keys",
+            lambda show_rk: {(1, 3): "EP-1-3", (2, 1): "EP-2-1"}
+            if show_rk == "SHOW100"
+            else {},
+        )
+        monkeypatch.setattr(
+            "synclet.plex.scrobble",
+            lambda rk, **_: called.append(rk) or True,
+        )
+        r = mark_watched_scope(
+            lib="tv", folder="Show", scope="episode", season=1, episode=3,
+        )
+        assert r["scrobbled"] == 1
+        assert called == ["EP-1-3"]
+
+    def test_season_scrobbles_only_that_season(self, monkeypatch):
+        called: list[str] = []
+        monkeypatch.setattr(
+            "synclet.plex.find_in_library",
+            lambda lib, folder: {"ratingKey": "SHOW100"},
+        )
+        monkeypatch.setattr(
+            "synclet.plex.episode_rating_keys",
+            lambda show_rk: {(1, 1): "E-1-1", (1, 2): "E-1-2", (2, 1): "E-2-1"},
+        )
+        monkeypatch.setattr(
+            "synclet.plex.scrobble",
+            lambda rk, **_: called.append(rk) or True,
+        )
+        r = mark_watched_scope(lib="tv", folder="Show", scope="season", season=1)
+        assert r["scrobbled"] == 2
+        # Both season-1 keys, none from season 2.
+        assert set(called) == {"E-1-1", "E-1-2"}
+
+    def test_series_scrobbles_all_episodes(self, monkeypatch):
+        called: list[str] = []
+        monkeypatch.setattr(
+            "synclet.plex.find_in_library",
+            lambda lib, folder: {"ratingKey": "SHOW100"},
+        )
+        monkeypatch.setattr(
+            "synclet.plex.episode_rating_keys",
+            lambda show_rk: {(1, 1): "A", (1, 2): "B", (2, 1): "C"},
+        )
+        monkeypatch.setattr(
+            "synclet.plex.scrobble",
+            lambda rk, **_: called.append(rk) or True,
+        )
+        r = mark_watched_scope(lib="tv", folder="Show", scope="series")
+        assert r["scrobbled"] == 3
+        assert set(called) == {"A", "B", "C"}
+
+    def test_partial_failure_does_not_abort_batch(self, monkeypatch):
+        """If one scrobble fails (network/timeout), the rest still run."""
+        monkeypatch.setattr(
+            "synclet.plex.find_in_library",
+            lambda lib, folder: {"ratingKey": "SHOW100"},
+        )
+        monkeypatch.setattr(
+            "synclet.plex.episode_rating_keys",
+            lambda show_rk: {(1, 1): "A", (1, 2): "FAIL", (1, 3): "C"},
+        )
+        monkeypatch.setattr(
+            "synclet.plex.scrobble",
+            lambda rk, **_: rk != "FAIL",
+        )
+        r = mark_watched_scope(lib="tv", folder="Show", scope="series")
+        assert r["scrobbled"] == 2
+        assert r["failed"] == 1
+        # Order preserved by sorted ep_map iteration
+        statuses = {(it["season"], it["episode"]): it["status"] for it in r["results"]}
+        assert statuses[(1, 1)] == "ok"
+        assert statuses[(1, 2)] == "scrobble_failed"
+        assert statuses[(1, 3)] == "ok"
+
+    def test_unknown_scope_returns_error(self):
+        r = mark_watched_scope(lib="tv", folder="Show", scope="bogus")
+        assert "error" in r
+        assert r["scrobbled"] == 0
+
+    def test_episode_scope_without_season_episode_errors(self):
+        r = mark_watched_scope(lib="tv", folder="Show", scope="episode")
+        assert "error" in r
+        assert r["scrobbled"] == 0

--- a/frontend/src/DetailDrawer.test.ts
+++ b/frontend/src/DetailDrawer.test.ts
@@ -104,6 +104,112 @@ describe("DetailDrawer mark-watched affordances", () => {
     store.detail = null
   })
 
+  it("keeps season-level mark-watched sticky against a stale refresh (the Unsettled bug)", async () => {
+    // Simulates the exact bug Jake hit: scrobble lands at Plex, frontend
+    // optimistically updates, then refreshInPlace fires and api.title()
+    // returns stale watchstate data (the daemon hasn't caught up). Without
+    // the session overlay, the optimistic update gets clobbered.
+    const { api } = await import("./api")
+    const STALE_FIXTURE = JSON.parse(JSON.stringify(SHOW_FIXTURE))
+
+    // First call: initial load returns unwatched (real Plex state).
+    // Subsequent calls (refreshInPlace) also return unwatched (stale DB).
+    ;(api.title as ReturnType<typeof vi.fn>).mockResolvedValue(STALE_FIXTURE)
+    // Scrobble route returns ok for both episodes.
+    ;(api.scrobble as ReturnType<typeof vi.fn>).mockResolvedValue({
+      scrobbled: 2,
+      failed: 0,
+      results: [
+        { season: 1, episode: 1, status: "ok" },
+        { season: 1, episode: 2, status: "ok" },
+      ],
+    })
+
+    store.detail = { lib: "tv", folder: "Test Show" }
+    const wrapper = mount(DetailDrawer)
+    await new Promise(r => setTimeout(r, 50))
+    await nextTick()
+
+    // Trigger season-level mark-watched. The script setup exposes markWatched
+    // indirectly through the season button.
+    const seasonBtn = wrapper.find('[data-testid="mark-season-watched"]')
+    expect(seasonBtn.exists()).toBe(true)
+
+    // Auto-confirm the window.confirm prompt (happy-dom may not define it).
+    window.confirm = () => true
+    await seasonBtn.trigger("click")
+    // Let the scrobble Promise + optimistic update flush.
+    await nextTick()
+    await new Promise(r => setTimeout(r, 50))
+    await nextTick()
+
+    // Trigger the refresh that previously clobbered the UI. The 1s timer
+    // fires inside markWatched; vi can't easily fast-forward the real
+    // setTimeout here without setting up fake timers, so we just call the
+    // refresh-equivalent: another mock api.title returns stale data,
+    // applyScrobbleOverlay should re-apply watched to the scrobbled episodes.
+    // We assert by reading the rendered DOM: the watched indicator (.ico.watched
+    // ●) should be present for both episodes.
+
+    // Wait a beat for the 1s refresh timer to fire.
+    await new Promise(r => setTimeout(r, 1200))
+    await nextTick()
+    await nextTick()
+
+    const html = wrapper.html()
+    // Both episodes should show the watched indicator (● in EpisodeTile) — the
+    // session overlay re-applied on the stale refresh.
+    const watchedDots = (html.match(/class="ico watched"/g) ?? []).length
+    expect(watchedDots).toBe(2)
+
+    store.detail = null
+  })
+
+  it("overlay survives drawer re-mount within the same session", async () => {
+    // User marks an episode watched, closes the drawer (navigates away),
+    // reopens it. WatchState still hasn't synced, so api.title returns the
+    // same stale unwatched state. The overlay must still re-apply.
+    const { api } = await import("./api")
+    const STALE = JSON.parse(JSON.stringify(SHOW_FIXTURE))
+    ;(api.title as ReturnType<typeof vi.fn>).mockResolvedValue(STALE)
+    ;(api.scrobble as ReturnType<typeof vi.fn>).mockResolvedValue({
+      scrobbled: 2, failed: 0,
+      results: [
+        { season: 1, episode: 1, status: "ok" },
+        { season: 1, episode: 2, status: "ok" },
+      ],
+    })
+    window.confirm = () => true
+
+    // First mount: open drawer, scrobble episode 1.
+    store.detail = { lib: "tv", folder: "Test Show" }
+    const w1 = mount(DetailDrawer)
+    await new Promise(r => setTimeout(r, 50))
+    await nextTick()
+    // Use the season-level button (always rendered when the season header is
+     // visible, no hover dependency).
+    const seasonBtn = w1.find('[data-testid="mark-season-watched"]')
+    expect(seasonBtn.exists()).toBe(true)
+    await seasonBtn.trigger("click")
+    await nextTick()
+    await new Promise(r => setTimeout(r, 50))
+    w1.unmount()
+    store.detail = null
+
+    // Second mount: same lib/folder, api still returns stale.
+    store.detail = { lib: "tv", folder: "Test Show" }
+    const w2 = mount(DetailDrawer)
+    await new Promise(r => setTimeout(r, 50))
+    await nextTick()
+
+    // The previously-scrobbled episode must still show as watched even
+    // though the API call returned unwatched.
+    const html = w2.html()
+    expect(html).toMatch(/class="ico watched"/)
+
+    store.detail = null
+  })
+
   it("does NOT render Mark watched on a movie pane when watched is true", async () => {
     const { api } = await import("./api")
     ;(api.title as ReturnType<typeof vi.fn>).mockResolvedValue({

--- a/frontend/src/DetailDrawer.test.ts
+++ b/frontend/src/DetailDrawer.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vitest"
+import { nextTick } from "vue"
+import { mount } from "@vue/test-utils"
+import DetailDrawer from "./components/DetailDrawer.vue"
+import { store } from "./store"
+
+vi.mock("./api", () => ({
+  api: {
+    artUrl: () => "",
+    title: vi.fn(),
+    scrobble: vi.fn().mockResolvedValue({
+      scrobbled: 1,
+      failed: 0,
+      results: [{ season: 1, episode: 1, status: "ok" }],
+    }),
+    sync: vi.fn(),
+    unsync: vi.fn(),
+  },
+}))
+
+const SHOW_FIXTURE = {
+  id: "tv/Test",
+  lib: "tv",
+  folder: "Test Show",
+  name: "Test Show",
+  kind: "show" as const,
+  year: 2024,
+  total_bytes: 0,
+  synced_bytes: 0,
+  files: [],
+  seasons: [
+    {
+      season: 1,
+      total_bytes: 0,
+      synced_episodes: 0,
+      watched_episodes: 0,
+      episodes: [
+        {
+          season: 1, episode: 1, title: "Pilot", size_bytes: 0,
+          files: [], is_synced: false,
+          watch_state: "unwatched" as const, watch_pct: 0,
+        },
+        {
+          season: 1, episode: 2, title: "Ep Two", size_bytes: 0,
+          files: [], is_synced: false,
+          watch_state: "unwatched" as const, watch_pct: 0,
+        },
+      ],
+    },
+  ],
+}
+
+const MOVIE_FIXTURE = {
+  id: "movies/M",
+  lib: "movies",
+  folder: "M",
+  name: "Movie M",
+  kind: "movie" as const,
+  year: 2024,
+  total_bytes: 0,
+  synced_bytes: 0,
+  files: [],
+  seasons: [],
+  watched: false,
+}
+
+describe("DetailDrawer mark-watched affordances", () => {
+  it("renders Mark series watched + Mark season watched + per-episode mark buttons", async () => {
+    const { api } = await import("./api")
+    ;(api.title as ReturnType<typeof vi.fn>).mockResolvedValue(SHOW_FIXTURE)
+    store.detail = { lib: "tv", folder: "Test Show" }
+
+    const wrapper = mount(DetailDrawer)
+    // wait for onMounted + load + render
+    await new Promise(r => setTimeout(r, 50))
+    await nextTick()
+    await nextTick()
+
+    const html = wrapper.html()
+    expect(html).toContain('data-testid="mark-series-watched"')
+    expect(html).toContain('data-testid="mark-season-watched"')
+    expect(html).toContain('data-testid="mark-episode-watched"')
+    expect(html).toContain("Mark series watched")
+    // Two episode tiles, each with its own mark-watched button
+    expect(html.match(/data-testid="mark-episode-watched"/g)?.length).toBe(2)
+
+    store.detail = null
+  })
+
+  it("renders Mark watched on the movie pane when movie is unwatched", async () => {
+    const { api } = await import("./api")
+    ;(api.title as ReturnType<typeof vi.fn>).mockResolvedValue(MOVIE_FIXTURE)
+    store.detail = { lib: "movies", folder: "M" }
+
+    const wrapper = mount(DetailDrawer)
+    await new Promise(r => setTimeout(r, 50))
+    await nextTick()
+    await nextTick()
+
+    const html = wrapper.html()
+    expect(html).toContain('data-testid="mark-movie-watched"')
+    expect(html).toContain("Mark watched")
+
+    store.detail = null
+  })
+
+  it("does NOT render Mark watched on a movie pane when watched is true", async () => {
+    const { api } = await import("./api")
+    ;(api.title as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ...MOVIE_FIXTURE,
+      watched: true,
+    })
+    store.detail = { lib: "movies", folder: "M" }
+
+    const wrapper = mount(DetailDrawer)
+    await new Promise(r => setTimeout(r, 50))
+    await nextTick()
+    await nextTick()
+
+    const html = wrapper.html()
+    expect(html).not.toContain('data-testid="mark-movie-watched"')
+
+    store.detail = null
+  })
+})

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -7,6 +7,8 @@ import type {
   ResolveAction,
   ResolveResponse,
   ResolveResult,
+  ScrobbleResponse,
+  ScrobbleScope,
   StateBundle,
   SyncedEntry,
   TitleDetail,
@@ -69,6 +71,20 @@ export const api = {
     }),
 
   refresh: () => json<{ ok: true }>("/api/refresh", { method: "POST" }),
+
+  scrobble: (body: ScrobbleBody) =>
+    json<ScrobbleResponse>(`/api/scrobble`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+}
+
+export interface ScrobbleBody {
+  lib: string
+  folder: string
+  scope: ScrobbleScope
+  season?: number
+  episode?: number
 }
 
 export interface SyncBody {

--- a/frontend/src/components/DetailDrawer.vue
+++ b/frontend/src/components/DetailDrawer.vue
@@ -2,7 +2,15 @@
 import { computed, onMounted, ref, watch } from "vue"
 import { api } from "../api"
 import type { Episode, TitleDetail } from "../types"
-import { closeDetail, humanSize, pushToast, store, trackJob } from "../store"
+import {
+  closeDetail,
+  humanSize,
+  isScrobbledThisSession,
+  pushToast,
+  recordScrobbled,
+  store,
+  trackJob,
+} from "../store"
 import EpisodeTile from "./EpisodeTile.vue"
 
 // How long after a sync/unsync job kicks off before we re-fetch the title
@@ -22,6 +30,33 @@ const submitting = ref(false)
 
 function key(s: number, e: number): string { return `${s}-${e}` }
 
+// Apply the session scrobble overlay to fresh title-detail data. Plex's
+// scrobble lands instantly but the WatchState daemon polls Plex on a slow
+// schedule (minutes), so api.title() can return watched=false for an episode
+// we successfully scrobbled seconds ago. Without this overlay, the UI would
+// flicker watched -> unwatched as refreshInPlace fires.
+function applyScrobbleOverlay(d: TitleDetail): TitleDetail {
+  if (d.kind === "movie") {
+    if (isScrobbledThisSession(d.lib, d.folder)) d.watched = true
+    return d
+  }
+  for (const s of d.seasons) {
+    let extraWatched = 0
+    for (const e of s.episodes) {
+      if (
+        isScrobbledThisSession(d.lib, d.folder, e.season, e.episode)
+        && e.watch_state !== "watched"
+      ) {
+        e.watch_state = "watched"
+        e.watch_pct = 100
+        extraWatched++
+      }
+    }
+    s.watched_episodes += extraWatched
+  }
+  return d
+}
+
 async function load(lib: string, folder: string): Promise<void> {
   loading.value = true
   error.value = ""
@@ -30,7 +65,7 @@ async function load(lib: string, folder: string): Promise<void> {
   lastClick.value = null
   expandedSeasons.value = new Set()
   try {
-    const d = await api.title(lib, folder)
+    const d = applyScrobbleOverlay(await api.title(lib, folder))
     detail.value = d
     // Expand the first season with unsynced or unwatched eps; otherwise season 1
     if (d.kind !== "movie" && d.seasons.length) {
@@ -53,7 +88,7 @@ async function refreshInPlace(lib: string, folder: string): Promise<void> {
     return
   }
   try {
-    const d = await api.title(lib, folder)
+    const d = applyScrobbleOverlay(await api.title(lib, folder))
     if (!detail.value || detail.value.lib !== lib || detail.value.folder !== folder) {
       return  // user navigated during the fetch
     }
@@ -287,29 +322,22 @@ async function markWatched(
       season,
       episode,
     })
-    // Optimistically reflect successful scrobbles in local state. Plex's
-    // WatchState daemon picks the change up on its next poll; until then,
-    // refreshInPlace would still show the stale watch state.
+    // Record successful scrobbles in the session overlay, then funnel the
+    // optimistic update through the same applyScrobbleOverlay helper that
+    // refreshInPlace uses. One code path = no drift between "fresh-mark
+    // optimistic update" and "post-refresh re-apply."
     if (detail.value.kind === "movie") {
-      if (r.scrobbled > 0) detail.value.watched = true
+      if (r.scrobbled > 0) {
+        recordScrobbled(detail.value.lib, detail.value.folder)
+      }
     } else {
-      const okSet = new Set(
-        r.results
-          .filter(it => it.status === "ok" && it.season !== null && it.episode !== null)
-          .map(it => `${it.season}-${it.episode}`),
-      )
-      for (const s of detail.value.seasons) {
-        let watchedDelta = 0
-        for (const e of s.episodes) {
-          if (okSet.has(`${e.season}-${e.episode}`) && e.watch_state !== "watched") {
-            e.watch_state = "watched"
-            e.watch_pct = 100
-            watchedDelta++
-          }
+      for (const it of r.results) {
+        if (it.status === "ok" && it.season !== null && it.episode !== null) {
+          recordScrobbled(detail.value.lib, detail.value.folder, it.season, it.episode)
         }
-        s.watched_episodes += watchedDelta
       }
     }
+    applyScrobbleOverlay(detail.value)
     if (r.error) {
       pushToast({ kind: "error", text: r.error })
     } else if (r.failed > 0) {

--- a/frontend/src/components/DetailDrawer.vue
+++ b/frontend/src/components/DetailDrawer.vue
@@ -2,7 +2,7 @@
 import { computed, onMounted, ref, watch } from "vue"
 import { api } from "../api"
 import type { Episode, TitleDetail } from "../types"
-import { closeDetail, humanSize, store, trackJob } from "../store"
+import { closeDetail, humanSize, pushToast, store, trackJob } from "../store"
 import EpisodeTile from "./EpisodeTile.vue"
 
 // How long after a sync/unsync job kicks off before we re-fetch the title
@@ -266,6 +266,75 @@ function toggleSeasonExpand(s: number): void {
   else expandedSeasons.value.add(s)
 }
 
+// ── Mark watched (explicit gesture, no file deletion) ──────────────────────
+
+async function markWatched(
+  scope: "movie" | "series" | "season" | "episode",
+  season?: number,
+  episode?: number,
+  confirmLabel?: string,
+): Promise<void> {
+  if (!detail.value) return
+  if (confirmLabel) {
+    if (!confirm(`Mark watched: ${confirmLabel}?`)) return
+  }
+  submitting.value = true
+  try {
+    const r = await api.scrobble({
+      lib: detail.value.lib,
+      folder: detail.value.folder,
+      scope,
+      season,
+      episode,
+    })
+    // Optimistically reflect successful scrobbles in local state. Plex's
+    // WatchState daemon picks the change up on its next poll; until then,
+    // refreshInPlace would still show the stale watch state.
+    if (detail.value.kind === "movie") {
+      if (r.scrobbled > 0) detail.value.watched = true
+    } else {
+      const okSet = new Set(
+        r.results
+          .filter(it => it.status === "ok" && it.season !== null && it.episode !== null)
+          .map(it => `${it.season}-${it.episode}`),
+      )
+      for (const s of detail.value.seasons) {
+        let watchedDelta = 0
+        for (const e of s.episodes) {
+          if (okSet.has(`${e.season}-${e.episode}`) && e.watch_state !== "watched") {
+            e.watch_state = "watched"
+            e.watch_pct = 100
+            watchedDelta++
+          }
+        }
+        s.watched_episodes += watchedDelta
+      }
+    }
+    if (r.error) {
+      pushToast({ kind: "error", text: r.error })
+    } else if (r.failed > 0) {
+      pushToast({
+        kind: "error",
+        text: `Marked ${r.scrobbled} watched, ${r.failed} failed`,
+      })
+    } else {
+      pushToast({
+        kind: "success",
+        text: `Marked ${r.scrobbled} watched`,
+      })
+    }
+    // Let WatchState catch up; this picks up any drift between optimistic and
+    // canonical state without resetting the UI.
+    const lib = detail.value.lib
+    const folder = detail.value.folder
+    setTimeout(() => refreshInPlace(lib, folder), UNSYNC_REFRESH_DELAY_MS)
+  } catch (e) {
+    pushToast({ kind: "error", text: (e as Error).message })
+  } finally {
+    submitting.value = false
+  }
+}
+
 function onBackdropClick(e: MouseEvent): void {
   if ((e.target as HTMLElement).classList.contains("backdrop")) closeDetail()
 }
@@ -329,6 +398,15 @@ const movieSynced = computed(() =>
               <button v-else class="danger" :disabled="submitting" @click="unsyncMovie">
                 Unsync
               </button>
+              <button
+                v-if="!detail.watched"
+                class="ghost"
+                :disabled="submitting"
+                data-testid="mark-movie-watched"
+                @click="markWatched('movie', undefined, undefined, detail.name)"
+              >
+                Mark watched
+              </button>
             </div>
           </div>
         </template>
@@ -341,6 +419,15 @@ const movieSynced = computed(() =>
             </button>
             <button class="ghost" @click="selectUnwatchedUnsynced">
               Unwatched + unsynced
+            </button>
+            <span class="spacer"></span>
+            <button
+              class="ghost"
+              :disabled="submitting"
+              data-testid="mark-series-watched"
+              @click="markWatched('series', undefined, undefined, `entire series ${detail.name}`)"
+            >
+              Mark series watched
             </button>
           </div>
 
@@ -356,6 +443,14 @@ const movieSynced = computed(() =>
                 <span v-if="s.synced_episodes" class="tag sync">{{ s.synced_episodes }} ⬇</span>
                 <span class="spacer"></span>
                 <button class="ghost mini" @click.stop="selectSeason(s.season)">select</button>
+                <button
+                  class="ghost mini"
+                  :disabled="submitting"
+                  data-testid="mark-season-watched"
+                  @click.stop="markWatched('season', s.season, undefined, `Season ${s.season}`)"
+                >
+                  ✓ season
+                </button>
               </header>
               <div v-show="expandedSeasons.has(s.season)" class="eps">
                 <EpisodeTile
@@ -364,6 +459,7 @@ const movieSynced = computed(() =>
                   :ep="e"
                   :selected="selected.has(key(e.season, e.episode))"
                   @toggle="toggle"
+                  @mark-watched="(season, episode) => markWatched('episode', season, episode)"
                 />
               </div>
             </section>

--- a/frontend/src/components/EpisodeTile.vue
+++ b/frontend/src/components/EpisodeTile.vue
@@ -3,16 +3,34 @@ import type { Episode } from "../types"
 import { epCode, humanSize } from "../store"
 
 defineProps<{ ep: Episode; selected: boolean }>()
-defineEmits<{ (e: "toggle", season: number, episode: number, shift: boolean): void }>()
+defineEmits<{
+  (e: "toggle", season: number, episode: number, shift: boolean): void
+  (e: "mark-watched", season: number, episode: number): void
+}>()
+
+function onKey(e: KeyboardEvent, season: number, episode: number): void {
+  // Enter / Space activate the tile, matching native <button> a11y semantics
+  // that we lost when switching the wrapper from <button> to <div role="button">
+  // (so a Mark-watched <button> can nest inside it — invalid HTML otherwise).
+  if (e.key === "Enter" || e.key === " ") {
+    e.preventDefault()
+    ;(e.currentTarget as HTMLElement).dispatchEvent(
+      new MouseEvent("click", { shiftKey: e.shiftKey, bubbles: true }),
+    )
+  }
+}
 </script>
 
 <template>
-  <button
+  <div
+    role="button"
+    tabindex="0"
     :class="[
       'tile',
       { selected, watched: ep.watch_state === 'watched', synced: ep.is_synced },
     ]"
     @click="$emit('toggle', ep.season, ep.episode, ($event as MouseEvent).shiftKey)"
+    @keydown="onKey($event, ep.season, ep.episode)"
   >
     <div class="row1">
       <span class="code mono">{{ epCode(ep.season, ep.episode) }}</span>
@@ -25,7 +43,16 @@ defineEmits<{ (e: "toggle", season: number, episode: number, shift: boolean): vo
     </div>
     <div class="title" :title="ep.title">{{ ep.title || "—" }}</div>
     <div class="meta dim">{{ humanSize(ep.size_bytes) }}</div>
-  </button>
+    <button
+      v-if="ep.watch_state !== 'watched'"
+      class="mark-watched-btn"
+      title="Mark watched"
+      data-testid="mark-episode-watched"
+      @click.stop="$emit('mark-watched', ep.season, ep.episode)"
+    >
+      ✓
+    </button>
+  </div>
 </template>
 
 <style scoped>
@@ -86,4 +113,33 @@ defineEmits<{ (e: "toggle", season: number, episode: number, shift: boolean): vo
   -webkit-box-orient: vertical;
 }
 .meta { font-size: 0.72rem; }
+
+.mark-watched-btn {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border-radius: 50%;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--fg-muted);
+  font-size: 0.78rem;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 80ms ease, background 80ms ease, color 80ms ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.tile:hover .mark-watched-btn,
+.tile:focus-within .mark-watched-btn {
+  opacity: 1;
+}
+.mark-watched-btn:hover {
+  background: var(--accent-watched, #4cc46c);
+  color: var(--bg);
+  border-color: transparent;
+}
 </style>

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -31,6 +31,32 @@ export interface Toast {
   jobId?: string
 }
 
+// Session-only overlay of items the user explicitly marked watched via the
+// Mark-watched buttons. We need this because Plex's scrobble is asynchronous
+// from Synclet's perspective: the WatchState daemon polls Plex on its own
+// schedule and the local SQLite DB lags by minutes. Without this overlay,
+// any refreshInPlace after a successful scrobble would re-read the stale
+// watchstate and overwrite the optimistic update — the checkmarks would
+// appear, then revert seconds later.
+//
+// Keyed by `${lib}/${folder}/${season}/${episode}` for episodes,
+// `${lib}/${folder}//` for movies. Cleared on page reload (intentional —
+// by then WatchState should have caught up).
+const scrobbledOverlay = new Set<string>()
+
+function overlayKey(lib: string, folder: string, season: number | null = null, episode: number | null = null): string {
+  return `${lib}/${folder}/${season ?? ""}/${episode ?? ""}`
+}
+
+export function recordScrobbled(lib: string, folder: string, season: number | null = null, episode: number | null = null): void {
+  scrobbledOverlay.add(overlayKey(lib, folder, season, episode))
+}
+
+/** True if (lib, folder, season?, episode?) was scrobbled in this session. */
+export function isScrobbledThisSession(lib: string, folder: string, season: number | null = null, episode: number | null = null): boolean {
+  return scrobbledOverlay.has(overlayKey(lib, folder, season, episode))
+}
+
 export const store = reactive<State>({
   titles: [],
   disk: null,

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -212,3 +212,18 @@ export interface RemoveResponse {
   bytes_freed: number
   cleanup: CleanupSummary
 }
+
+export type ScrobbleScope = "movie" | "series" | "season" | "episode"
+
+export interface ScrobbleItemResult {
+  season: number | null
+  episode: number | null
+  status: "ok" | "scrobble_failed" | "no_rating_key"
+}
+
+export interface ScrobbleResponse {
+  scrobbled: number
+  failed: number
+  results: ScrobbleItemResult[]
+  error?: string
+}


### PR DESCRIPTION
## Summary

Closes #15. Adds an explicit mark-watched flow distinct from the
deletion-driven resolve path:

- **Movie pane**: Mark watched button (hidden when already watched).
- **Series**: Mark series watched in the actions-row.
- **Season**: ✓ season mini-button next to the existing "select".
- **Episode**: a ✓ button per tile, surfaces on hover, hides when already watched.

The file stays on disk; only Plex's watch state is updated. WatchState's
daemon picks up the change on its next poll, so the grid view reflects
the new state shortly after. The UI also optimistically updates local
state on success so the user sees feedback immediately.

## Backend

New route `POST /api/scrobble`:

```json
{ "lib": "tv", "folder": "...", "scope": "movie"|"series"|"season"|"episode", "season"?: N, "episode"?: N }
```

Returns `{"scrobbled": N, "failed": N, "results": [{season, episode, status}]}`. Partial failures don't abort the batch.

Backed by `synclet.pending.mark_watched_scope`, which reuses
`plex.find_in_library`, `plex.episode_rating_keys`, and `plex.scrobble`
already in place from #10 — no new wire surface against Plex.

## Live verification

```
$ curl -X POST -H 'Content-Type: application/json' \
    -d '{"lib":"tv","folder":"3 Body Problem (2024) {tvdb-422089}","scope":"episode","season":1,"episode":1}' \
    http://192.168.86.183:1314/api/scrobble
{"scrobbled": 1, "failed": 0, "results": [{"season": 1, "episode": 1, "status": "ok"}]}
```

Plex's viewCount on the episode incremented as expected — `watched` state
preserved (it was already watched). Cumulative test runs across PRs #10,
#12, and this one have left 3 Body Problem S01E01 at viewCount=3.

## Test plan

- [x] Backend: 11 new tests for `mark_watched_scope` (movie, episode,
  season, series scopes; partial failure; unknown scope; missing
  season/episode for episode scope)
- [x] Backend: API route tests for `/api/scrobble`
- [x] Backend: 146 pytest pass, pyright clean
- [x] Frontend: 3 new tests in `DetailDrawer.test.ts` assert the
  series/season/episode/movie buttons render at the right levels and
  hide when already watched
- [x] Frontend: 24 vitest pass
- [x] Live verification against real Plex returned `status="ok"`

## Note on EpisodeTile refactor

EpisodeTile's outer wrapper was a `<button>`. Per-episode mark-watched
requires a nested `<button>`, which is invalid HTML. Refactored to
`<div role="button" tabindex="0">` with explicit keyboard handling
(`Enter` / `Space`) to preserve a11y. Single-click selection unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)