### PR TITLE
Tab badges for Maintenance + Watchlist counts, poster alignment polish

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -316,6 +316,26 @@ async def api_maint_remove(data: RemoveFilesRequest) -> dict:
     return sync_ops.remove_files(data.paths)
 
 
+@get("/api/maintenance/counts")
+async def api_maint_counts() -> dict:
+    """Actionable-item counts for the Maintenance tab badge.
+
+    Sum is what TabBar surfaces as a single number. Per-category counts are
+    exposed too so the UI can target a specific section without re-fetching.
+    Walks the filesystem (cheap at homelab scale, <1s for ~hundreds of files);
+    callers should debounce or fetch on tab focus rather than every render.
+    """
+    watched = sync_ops.find_watched_synced_files()
+    hanging = sync_ops.find_hanging_files()
+    pending_items = pending.compute_pending()
+    return {
+        "watched_titles": len(watched),
+        "hanging_files": len(hanging),
+        "pending_items": len(pending_items),
+        "total": len(watched) + len(hanging) + len(pending_items),
+    }
+
+
 @get("/api/maintenance/pending")
 async def api_maint_pending() -> dict:
     """Synced items whose files were deleted since the last snapshot.
@@ -403,6 +423,7 @@ app = Litestar(
         api_maint_watched,
         api_maint_hanging,
         api_maint_remove,
+        api_maint_counts,
         api_maint_pending,
         api_maint_resolve,
         api_scrobble,

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -141,6 +141,30 @@ class TestSyncRoute:
             assert "total_bytes" in body
 
 
+class TestMaintenanceCountsRoute:
+    def test_returns_all_keys(self, client):
+        r = client.get("/api/maintenance/counts")
+        assert r.status_code == 200
+        body = r.json()
+        # Wire contract: TabBar consumes `total`; per-category counts let the
+        # UI deep-link without a second round-trip.
+        required = {"watched_titles", "hanging_files", "pending_items", "total"}
+        assert required <= body.keys(), f"missing: {required - body.keys()}"
+
+    def test_total_equals_sum_of_categories(self, client, patch_paths):
+        from synclet.pending import SnapshotKey, save_snapshot
+
+        # Seed one ghost pending so total is non-zero.
+        save_snapshot({SnapshotKey(sync_sub="tv", folder="Ghost", season=1, episode=1)})
+        r = client.get("/api/maintenance/counts")
+        body = r.json()
+        assert body["total"] == (
+            body["watched_titles"] + body["hanging_files"] + body["pending_items"]
+        )
+        # The ghost we seeded shows in pending_items.
+        assert body["pending_items"] >= 1
+
+
 class TestMaintenancePendingRoute:
     def test_empty_initially(self, client):
         # First call bootstraps the snapshot from current disk state.

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -11,7 +11,13 @@ import MaintenanceView from "./components/MaintenanceView.vue"
 import LinkPasteModal from "./components/LinkPasteModal.vue"
 import JobToasts from "./components/JobToasts.vue"
 import { api } from "./api"
-import { loadState, pushToast, store } from "./store"
+import {
+  loadMaintenanceCount,
+  loadState,
+  loadWatchlistCount,
+  pushToast,
+  store,
+} from "./store"
 
 const showPaste = ref(false)
 
@@ -19,11 +25,20 @@ onMounted(() => {
   loadState().catch(e => {
     pushToast({ kind: "error", text: `Failed to load state: ${(e as Error).message}` })
   })
+  loadMaintenanceCount()
+  loadWatchlistCount()
 })
 
 const counts = computed(() => ({
   library: store.titles.length,
   synced: store.disk?.synced_titles ?? 0,
+  watchlist: store.watchlistCount ?? undefined,
+  // Maintenance is "attention required" not "inventory" — only badge when
+  // the count is positive. 0 means the user has nothing to do; no badge.
+  maintenance:
+    store.maintenanceCount != null && store.maintenanceCount > 0
+      ? store.maintenanceCount
+      : undefined,
 }))
 
 async function refresh(): Promise<void> {

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,6 +1,7 @@
 import type {
   HangingFile,
   Job,
+  MaintenanceCounts,
   PendingGroup,
   PendingItemRef,
   RemoveResponse,
@@ -57,6 +58,7 @@ export const api = {
       method: "POST",
       body: JSON.stringify({ paths }),
     }),
+  maintCounts: () => json<MaintenanceCounts>(`/api/maintenance/counts`),
   maintPending: () => json<{ items: PendingGroup[] }>(`/api/maintenance/pending`),
   maintResolve: (items: PendingItemRef[], action: ResolveAction) =>
     json<ResolveResponse>(`/api/maintenance/resolve`, {

--- a/frontend/src/components/MaintenanceView.vue
+++ b/frontend/src/components/MaintenanceView.vue
@@ -11,7 +11,7 @@ import type {
   ResolveItemResult,
   WatchedFiles,
 } from "../types"
-import { humanSize, loadState, pushToast } from "../store"
+import { humanSize, loadMaintenanceCount, loadState, pushToast } from "../store"
 
 const watched = ref<WatchedFiles[]>([])
 const hanging = ref<HangingFile[]>([])
@@ -36,6 +36,10 @@ async function load(): Promise<void> {
     watched.value = w.items
     hanging.value = h.items
     pending.value = p.items
+    // Surface the same counts to the tab badge. Cheap: load() already did
+    // the FS walks the counts endpoint would do; this round-trip just sums
+    // them server-side.
+    loadMaintenanceCount()
   } catch (e) {
     error.value = (e as Error).message
   } finally {

--- a/frontend/src/components/TitleCard.vue
+++ b/frontend/src/components/TitleCard.vue
@@ -152,6 +152,11 @@ const thumbUrl = api.thumbUrl(props.title.lib, props.title.folder)
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   margin-bottom: 2px;
+  /* Reserve two lines of space even for single-line names so the .info
+     section has a constant height. Without this, a one-line name shrinks
+     the card and the grid row's align-items: stretch behavior pushes
+     short-name posters down a few pixels relative to two-line neighbours. */
+  min-height: calc(2 * 1.25em);
 }
 .meta {
   font-size: 0.75rem;

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -19,6 +19,12 @@ interface State {
   // Drawer
   detail: { lib: string; folder: string } | null
 
+  // Tab badge counts. Maintenance is the sum of actionable items
+  // (pending + watched-in-synced + hanging); Watchlist is the watchlist
+  // item count. Refreshed on app mount and after relevant actions.
+  maintenanceCount: number | null
+  watchlistCount: number | null
+
   // Jobs
   jobs: Record<string, Job>
   toasts: Toast[]
@@ -70,6 +76,9 @@ export const store = reactive<State>({
 
   detail: null,
 
+  maintenanceCount: null,
+  watchlistCount: null,
+
   jobs: {},
   toasts: [],
 })
@@ -92,6 +101,28 @@ export async function loadState(refresh = false): Promise<void> {
     }
   })()
   return stateInflight
+}
+
+// Tab-badge count loaders. Failures intentionally swallow into null so the
+// badge just disappears instead of throwing; counts are advisory UI, not
+// load-bearing.
+
+export async function loadMaintenanceCount(): Promise<void> {
+  try {
+    const r = await api.maintCounts()
+    store.maintenanceCount = r.total
+  } catch {
+    store.maintenanceCount = null
+  }
+}
+
+export async function loadWatchlistCount(): Promise<void> {
+  try {
+    const r = await api.watchlist()
+    store.watchlistCount = r.items.length
+  } catch {
+    store.watchlistCount = null
+  }
 }
 
 // ── Filters ────────────────────────────────────────────────────────────────

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -227,3 +227,10 @@ export interface ScrobbleResponse {
   results: ScrobbleItemResult[]
   error?: string
 }
+
+export interface MaintenanceCounts {
+  watched_titles: number
+  hanging_files: number
+  pending_items: number
+  total: number
+}


### PR DESCRIPTION
## Summary

Three small things:

1. **Maintenance tab badge** — surfaces a count when there's something to
   attend to. Sum of pending + watched-in-synced + hanging. Badge
   appears only when count > 0 (no "0" badge for a quiet tab).
2. **Watchlist tab badge** — count of watchlist items, always shown.
3. **Title card poster alignment** — single-line names no longer shift
   posters up by a few pixels relative to two-line names. The .name
   block has a constant two-line height; row gets a little taller, but
   poster tops align across the entire grid row.

## Backend

`GET /api/maintenance/counts` returns:

```json
{ "watched_titles": 2, "hanging_files": 21, "pending_items": 1, "total": 24 }
```

Frontend uses `total` for the badge; per-category counts are exposed for
future deep-linking.

## Live verification

```
$ curl http://192.168.86.183:1314/api/maintenance/counts
{"watched_titles":2,"hanging_files":21,"pending_items":1,"total":24}
```

Backend gate: 137 pytest pass. Frontend gate: 21 vitest pass.

## Related

- #17 filed for the separate "remove from Plex watchlist after marking
  watched" feature — needs Plex.tv discovery API auth research, distinct
  from the local server API used today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)