### PR TITLE
Perf: TTL cache slow maintenance walks + optimistic Ignore (Closes #21)

### DIFF
--- a/backend/synclet/ignored.py
+++ b/backend/synclet/ignored.py
@@ -160,11 +160,19 @@ def save(state: IgnoredState) -> None:
 # ── Mutation API ─────────────────────────────────────────────────────────────
 
 
+def _invalidate_maint_cache() -> None:
+    """Cache invalidation hook; local import keeps the module graph small."""
+    from synclet.maint_cache import invalidate  # noqa: PLC0415
+
+    invalidate()
+
+
 def ignore_pending(ref: PendingRef) -> None:
     """Add a pending key to the ignored set; idempotent."""
     state = load()
     state.pending.add(ref)
     save(state)
+    _invalidate_maint_cache()
 
 
 def unignore_pending(ref: PendingRef) -> None:
@@ -172,6 +180,7 @@ def unignore_pending(ref: PendingRef) -> None:
     state = load()
     state.pending.discard(ref)
     save(state)
+    _invalidate_maint_cache()
 
 
 def ignore_watched(ref: WatchedRef) -> None:
@@ -179,6 +188,7 @@ def ignore_watched(ref: WatchedRef) -> None:
     state = load()
     state.watched.add(ref)
     save(state)
+    _invalidate_maint_cache()
 
 
 def unignore_watched(ref: WatchedRef) -> None:
@@ -186,6 +196,7 @@ def unignore_watched(ref: WatchedRef) -> None:
     state = load()
     state.watched.discard(ref)
     save(state)
+    _invalidate_maint_cache()
 
 
 def ignore_hanging(ref: HangingRef) -> None:
@@ -193,6 +204,7 @@ def ignore_hanging(ref: HangingRef) -> None:
     state = load()
     state.hanging.add(ref)
     save(state)
+    _invalidate_maint_cache()
 
 
 def unignore_hanging(ref: HangingRef) -> None:
@@ -200,6 +212,7 @@ def unignore_hanging(ref: HangingRef) -> None:
     state = load()
     state.hanging.discard(ref)
     save(state)
+    _invalidate_maint_cache()
 
 
 # ── Filter helpers (used by producers) ───────────────────────────────────────
@@ -242,7 +255,8 @@ def ignore_ref(kind: str, ref: dict) -> bool:
     """Dispatch an ignore call by kind discriminator; returns True on success.
 
     Validates the kind and the ref shape per kind. Returns False if either is
-    malformed so the caller can surface a friendly error.
+    malformed so the caller can surface a friendly error. The per-kind
+    `ignore_*` callees handle cache invalidation.
     """
     try:
         if kind == "pending":

--- a/backend/synclet/maint_cache.py
+++ b/backend/synclet/maint_cache.py
@@ -1,0 +1,54 @@
+"""TTL cache for expensive maintenance filesystem walks.
+
+`find_watched_synced_files`, `find_hanging_files`, and `compute_pending`
+each iterate SYNC_ROOT, which is shfs FUSE on the deploy target and ~10x
+slower than native ext4 for rglob-style ops. The Maintenance tab hits
+all three on every render (via the four producer endpoints AND the
+counts endpoint), so a tab switch can take noticeable seconds.
+
+This module wraps each producer with a TTL cache that mirrors the
+state-grid pattern in `synclet/state.py`. Mutating actions
+(sync/unsync/remove/resolve/ignore/unignore) call `invalidate()` to
+clear the cache; the next read recomputes once and serves subsequent
+reads from memory for STATE_CACHE_TTL seconds.
+
+Cache lives in-process. Two implications:
+- A uvicorn restart cold-starts the cache. Acceptable.
+- A multi-worker uvicorn would have per-worker caches that drift. Not
+  a concern today (single-worker config); flagged here for future.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from synclet.config import STATE_CACHE_TTL
+
+_cache: dict[str, tuple[float, Any]] = {}
+
+
+def get_cached(key: str, build: callable) -> Any:  # noqa: ANN401 — generic cache value
+    """Return cached value for `key`, recomputing via `build()` on miss/expire.
+
+    The `build` callable runs synchronously and replaces the cache entry
+    on every recompute. Errors propagate so callers see them on the API
+    boundary instead of silently caching empty data.
+    """
+    now = time.time()
+    entry = _cache.get(key)
+    if entry is not None and now - entry[0] < STATE_CACHE_TTL:
+        return entry[1]
+    value = build()
+    _cache[key] = (now, value)
+    return value
+
+
+def invalidate() -> None:
+    """Clear all maintenance caches.
+
+    Called by every mutating action so the next read recomputes. Cheap;
+    the next read pays the FS-walk cost once, subsequent reads are free
+    until TTL.
+    """
+    _cache.clear()

--- a/backend/synclet/pending.py
+++ b/backend/synclet/pending.py
@@ -275,11 +275,11 @@ def keys_for_paths(paths: Iterable[str | Path]) -> set[SnapshotKey]:
 # ── Pending computation ─────────────────────────────────────────────────────
 
 
-def compute_pending() -> set[SnapshotKey]:
-    """Return the set of SnapshotKeys present in the snapshot but not on disk.
+def _compute_pending_uncached() -> set[SnapshotKey]:
+    """Walk SYNC_ROOT + intersect with snapshot + filter ignored.
 
-    Excludes user-muted entries from synclet.ignored so the maintenance UI
-    and the Maintenance tab badge both honor the mute.
+    The expensive part is scan_on_disk's filesystem walk on shfs FUSE.
+    Callers should go through `compute_pending()` for the cached path.
     """
     from synclet.ignored import PendingRef, ignored_pending_set  # noqa: PLC0415
 
@@ -299,6 +299,19 @@ def compute_pending() -> set[SnapshotKey]:
         )
         not in ignored
     }
+
+
+def compute_pending() -> set[SnapshotKey]:
+    """Return the set of SnapshotKeys present in the snapshot but not on disk.
+
+    Excludes user-muted entries from synclet.ignored so the maintenance UI
+    and the Maintenance tab badge both honor the mute. Cached via
+    `maint_cache` for STATE_CACHE_TTL seconds; invalidated by every
+    mutating maintenance action.
+    """
+    from synclet.maint_cache import get_cached  # noqa: PLC0415
+
+    return get_cached("pending", _compute_pending_uncached)
 
 
 # ── Post-resolve filesystem cleanup ─────────────────────────────────────────
@@ -571,10 +584,13 @@ def resolve(
     keys = list(keys)
     results: list[ResolveResult] = []
 
+    from synclet.maint_cache import invalidate as invalidate_maint_cache  # noqa: PLC0415
+
     if not confirm:
         results.extend(ResolveResult(key=k, status="rejected") for k in keys)
         remove_keys(keys)
         cleanup = aggregate_cleanup(keys)
+        invalidate_maint_cache()
         return results, cleanup
 
     for k in keys:
@@ -601,6 +617,7 @@ def resolve(
 
     remove_keys(keys)
     cleanup = aggregate_cleanup(keys)
+    invalidate_maint_cache()
     return results, cleanup
 
 

--- a/backend/synclet/sync_ops.py
+++ b/backend/synclet/sync_ops.py
@@ -22,6 +22,7 @@ from synclet.fs_helpers import iter_sync_subs, iter_synced_titles
 from synclet.scan import is_wanted_file, scan_title_detail
 from synclet import pending as pending_mod
 from synclet import state as state_mod
+from synclet.maint_cache import invalidate as _invalidate_maint_cache
 
 
 @dataclass
@@ -190,6 +191,7 @@ async def _run_sync(job: Job) -> None:
     finally:
         job.ended_at = time.time()
         state_mod.invalidate()
+        _invalidate_maint_cache()
 
 
 async def _run_unsync(job: Job) -> None:
@@ -230,6 +232,7 @@ async def _run_unsync(job: Job) -> None:
     finally:
         job.ended_at = time.time()
         state_mod.invalidate()
+        _invalidate_maint_cache()
 
 
 def start_sync(pairs: list[tuple[Path, Path]], title: str = "") -> Job:
@@ -296,12 +299,8 @@ def find_source_lib(folder_name: str) -> str | None:
     return None
 
 
-def find_watched_synced_files() -> list[dict]:
-    """Files in SYNC_ROOT that correspond to watched episodes/movies.
-
-    Returns [{title, lib, files: [paths], size}] grouped by title. Excludes
-    user-muted entries from synclet.ignored.
-    """
+def _find_watched_synced_files_uncached() -> list[dict]:
+    """The expensive watched-files walk; callers should use the cached wrapper."""
     from synclet.scan import clean_name, _EP_PAT, _season_num
     from synclet.watchstate import show_watch_map, movie_watch_state
     from synclet.ignored import WatchedRef, ignored_watched_set
@@ -359,8 +358,15 @@ def find_watched_synced_files() -> list[dict]:
     return out
 
 
-def find_hanging_files() -> list[dict]:
-    """Sync-root files in folders with no video file. Excludes user-muted paths."""
+def find_watched_synced_files() -> list[dict]:
+    """Cached wrapper: see _find_watched_synced_files_uncached."""
+    from synclet.maint_cache import get_cached
+
+    return get_cached("watched", _find_watched_synced_files_uncached)
+
+
+def _find_hanging_files_uncached() -> list[dict]:
+    """The expensive hanging-files walk; callers should use the cached wrapper."""
     from synclet.ignored import HangingRef, ignored_hanging_set
 
     ignored_paths = {h.path for h in ignored_hanging_set()}
@@ -391,6 +397,13 @@ def find_hanging_files() -> list[dict]:
     return hanging
 
 
+def find_hanging_files() -> list[dict]:
+    """Cached wrapper: see _find_hanging_files_uncached."""
+    from synclet.maint_cache import get_cached
+
+    return get_cached("hanging", _find_hanging_files_uncached)
+
+
 def remove_files(paths: list[str]) -> dict:
     # Translate to snapshot keys BEFORE deleting; path_to_snapshot_key reads
     # the file extension, not the inode, so post-delete translation still
@@ -411,6 +424,7 @@ def remove_files(paths: list[str]) -> dict:
             except OSError:
                 continue
     state_mod.invalidate()
+    _invalidate_maint_cache()
     # Implicit confirm: the maintenance "remove watched" path means the user
     # already watched these in Plex. Drop them from the snapshot so they do
     # NOT later appear as pending deletions.

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -160,8 +160,10 @@ def patch_paths(
     monkeypatch.setattr("synclet.ignored.IGNORED_FILE", ignored_file)
 
     # State cache holds previous-test data; invalidate every test.
-    from synclet import state as state_mod
+    from synclet import maint_cache, state as state_mod
 
     state_mod.invalidate()
+    maint_cache.invalidate()
     yield media_tree
     state_mod.invalidate()
+    maint_cache.invalidate()

--- a/backend/tests/test_ignored.py
+++ b/backend/tests/test_ignored.py
@@ -117,6 +117,37 @@ class TestListGrouped:
 # ── Integration: producers filter ignored ────────────────────────────────────
 
 
+class TestCacheInvalidation:
+    """Mutating actions must clear maint_cache so the next read recomputes."""
+
+    def test_ignore_invalidates_cache(self, patch_paths):
+        from synclet import maint_cache
+
+        # Prime the cache with a sentinel value.
+        maint_cache._cache["pending"] = (0.0, "stale")
+        # Just calling time.time() picks up the stale-since-epoch entry, so
+        # we use the actual cache helper to set a fresh-but-known value.
+        import time
+
+        maint_cache._cache["pending"] = (time.time(), "stale")
+        assert maint_cache._cache.get("pending", (0, None))[1] == "stale"
+
+        ignore_pending(PendingRef(sync_sub="tv", folder="X", season=1, episode=1))
+        # invalidate() should have cleared the cache entry.
+        assert "pending" not in maint_cache._cache
+
+    def test_unignore_invalidates_cache(self, patch_paths):
+        from synclet import maint_cache
+        import time
+
+        ignore_pending(PendingRef(sync_sub="tv", folder="Y", season=1, episode=1))
+        # Re-prime after the previous invalidation.
+        maint_cache._cache["pending"] = (time.time(), "stale")
+
+        unignore_pending(PendingRef(sync_sub="tv", folder="Y", season=1, episode=1))
+        assert "pending" not in maint_cache._cache
+
+
 class TestPendingFilters:
     def test_ignored_pending_disappears_from_compute_pending(
         self, patch_paths, patch_snapshot_for_pending

--- a/frontend/src/components/MaintenanceView.vue
+++ b/frontend/src/components/MaintenanceView.vue
@@ -13,7 +13,7 @@ import type {
   ResolveItemResult,
   WatchedFiles,
 } from "../types"
-import { humanSize, loadMaintenanceCount, loadState, pushToast } from "../store"
+import { humanSize, loadMaintenanceCount, loadState, pushToast, store } from "../store"
 
 const watched = ref<WatchedFiles[]>([])
 const hanging = ref<HangingFile[]>([])
@@ -59,21 +59,107 @@ const ignoredCount = computed(() =>
   + ignoredList.value.hanging.length
 )
 
-async function ignoreItem(kind: IgnoreKind, ref: object, label: string): Promise<void> {
+// Mutate the local lists without re-fetching from the server. The
+// server-side cache TTL (30s) means a reload would still be slow even after
+// the invalidation triggered by the ignore call. Optimistic UI keeps the
+// click snappy; on error we restore the entry and surface the error.
+
+function removePendingLocal(kind: IgnoreKind, ref: any): void {
+  if (kind === "watched") {
+    watched.value = watched.value.filter(
+      w => !(w.lib === ref.lib && w.folder === ref.folder),
+    )
+  } else if (kind === "hanging") {
+    hanging.value = hanging.value.filter(h => h.path !== ref.path)
+  } else if (kind === "pending") {
+    if (ref.season === null || ref.season === undefined) {
+      // Movie-level pending: drop the entire group.
+      pending.value = pending.value.filter(
+        g => !(g.sync_sub === ref.sync_sub && g.folder === ref.folder),
+      )
+    } else {
+      // Episode-level pending: drop the episode; if the season becomes
+      // empty, drop the season; if the group becomes empty, drop the group.
+      pending.value = pending.value
+        .map(g => {
+          if (g.sync_sub !== ref.sync_sub || g.folder !== ref.folder) return g
+          const seasons = (g.seasons ?? [])
+            .map(s => {
+              if (s.season !== ref.season) return s
+              return { ...s, episodes: s.episodes.filter(e => e.episode !== ref.episode) }
+            })
+            .filter(s => s.episodes.length > 0)
+          return { ...g, seasons }
+        })
+        .filter(g => g.kind === "movie" || (g.seasons?.length ?? 0) > 0)
+    }
+  }
+}
+
+async function ignoreItem(kind: IgnoreKind, ref: any, label: string): Promise<void> {
+  // Snapshot for rollback on error.
+  const snapshot = {
+    watched: watched.value,
+    hanging: hanging.value,
+    pending: pending.value,
+    ignoredList: ignoredList.value,
+  }
+  // Optimistic: drop from source list immediately.
+  removePendingLocal(kind, ref)
+  // Add to the ignored list so the Ignored section reflects it without a refetch.
+  if (kind === "watched") {
+    ignoredList.value = {
+      ...ignoredList.value,
+      watched: [...ignoredList.value.watched, ref],
+    }
+  } else if (kind === "hanging") {
+    ignoredList.value = {
+      ...ignoredList.value,
+      hanging: [...ignoredList.value.hanging, ref],
+    }
+  } else {
+    ignoredList.value = {
+      ...ignoredList.value,
+      pending: [...ignoredList.value.pending, {
+        sync_sub: ref.sync_sub,
+        folder: ref.folder,
+        season: ref.season ?? null,
+        episode: ref.episode ?? null,
+      }],
+    }
+  }
+  // Decrement the tab badge locally so it updates instantly.
+  if (typeof store.maintenanceCount === "number") {
+    store.maintenanceCount = Math.max(0, store.maintenanceCount - 1)
+  }
+
   try {
     const r = await api.maintIgnore(kind, ref)
     if (!r.ok) {
+      // Rollback
+      watched.value = snapshot.watched
+      hanging.value = snapshot.hanging
+      pending.value = snapshot.pending
+      ignoredList.value = snapshot.ignoredList
+      loadMaintenanceCount()
       pushToast({ kind: "error", text: `Could not ignore ${label}` })
       return
     }
     pushToast({ kind: "success", text: `Ignored ${label}` })
-    await load()
   } catch (e) {
+    watched.value = snapshot.watched
+    hanging.value = snapshot.hanging
+    pending.value = snapshot.pending
+    ignoredList.value = snapshot.ignoredList
+    loadMaintenanceCount()
     pushToast({ kind: "error", text: (e as Error).message })
   }
 }
 
-async function unignoreItem(kind: IgnoreKind, ref: object, label: string): Promise<void> {
+async function unignoreItem(kind: IgnoreKind, ref: any, label: string): Promise<void> {
+  // Unignore needs a refetch because the entry has to reappear in its
+  // original source list, and we don't have all the fields (size, files)
+  // locally to reconstruct it.
   try {
     const r = await api.maintUnignore(kind, ref)
     if (!r.ok) {


### PR DESCRIPTION
## Summary

Two related slownesses fixed:

1. **Clicking Ignore was sluggish** because it triggered a full
   `load()` re-fetching four maintenance endpoints, three of which
   walk the filesystem.
2. **Synced / Watchlist / Maintenance tabs took seconds** because
   every render hit fresh FS walks on shfs FUSE.

## Fix

- **Server-side TTL cache** (`synclet/maint_cache.py`) wraps the three
  expensive walks: `compute_pending`, `find_watched_synced_files`,
  `find_hanging_files`. TTL = `STATE_CACHE_TTL` (30s default).
- **Invalidation hooks** at every mutating path: sync completion,
  unsync completion, manual remove, resolve confirm + reject, and
  ignore/unignore on all three kinds.
- **Optimistic frontend Ignore**: remove from local lists, decrement
  `store.maintenanceCount` inline. On error: snapshot rollback +
  count refetch. Unignore stays a refetch because reconstructing a
  row without a fetch would be brittle (sizes, files).

## Live verification

```
cold /api/maintenance/counts:  15.4s (shfs walk)
warm /api/maintenance/counts:  11ms  (1400x faster)

POST /api/maintenance/ignore (a hanging file)
cold /api/maintenance/counts:  16.2s (recompute, total dropped 21 -> 20)
warm /api/maintenance/counts:  31ms
```

## Test plan

- [x] 169 backend pass (2 new cache-invalidation tests)
- [x] Conftest invalidates the cache between tests so isolation holds
- [x] 26 frontend vitest pass (render test still asserts mock shapes)
- [x] Live cold/warm timing measured; invalidate-on-ignore verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)