### PR TITLE
Perf: optimistic Remove + KeepAlive across tab switches (Closes #23)

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -70,14 +70,21 @@ window.addEventListener("keydown", onKeydown)
     <TabBar :tab="store.tab" :counts="counts" @change="t => (store.tab = t)" />
 
     <main class="main">
+      <!-- KeepAlive preserves Synced / Watchlist / Maintenance state across
+           tab switches so leaving and returning is instant. Once loaded,
+           these views stay mounted and re-show without re-fetching. Library
+           is excluded because its TitleGrid is already store-backed and
+           cheap to remount. -->
       <template v-if="store.tab === 'library'">
         <FilterBar />
         <TitleGrid v-if="store.loaded" />
         <div v-else class="loading">Loading library…</div>
       </template>
-      <SyncedView      v-else-if="store.tab === 'synced'" />
-      <WatchlistView   v-else-if="store.tab === 'watchlist'" />
-      <MaintenanceView v-else-if="store.tab === 'maintenance'" />
+      <KeepAlive v-else>
+        <SyncedView      v-if="store.tab === 'synced'" />
+        <WatchlistView   v-else-if="store.tab === 'watchlist'" />
+        <MaintenanceView v-else-if="store.tab === 'maintenance'" />
+      </KeepAlive>
     </main>
 
     <DetailDrawer v-if="store.detail" />

--- a/frontend/src/components/MaintenanceView.vue
+++ b/frontend/src/components/MaintenanceView.vue
@@ -287,6 +287,23 @@ const totalPendingEpisodes = computed(() =>
 async function removePaths(paths: string[], label: string): Promise<void> {
   if (paths.length === 0) return
   if (!confirm(`Remove ${paths.length} file${paths.length === 1 ? "" : "s"}?\n\n${label}`)) return
+  // Optimistic: drop the matching rows from local state immediately so the
+  // UI updates without waiting for the (cold) re-walk that follows the
+  // server-side cache invalidation. Snapshot for rollback.
+  const pathSet = new Set(paths)
+  const snapshotW = watched.value
+  const snapshotH = hanging.value
+  watched.value = watched.value
+    .map(w => ({ ...w, files: w.files.filter(p => !pathSet.has(p)) }))
+    .filter(w => w.files.length > 0)
+  hanging.value = hanging.value.filter(h => !pathSet.has(h.path))
+  // Approximate badge decrement: number of titles+files dropped from view.
+  const dropped =
+    (snapshotW.length - watched.value.length)
+    + (snapshotH.length - hanging.value.length)
+  if (typeof store.maintenanceCount === "number" && dropped > 0) {
+    store.maintenanceCount = Math.max(0, store.maintenanceCount - dropped)
+  }
   removing.value = true
   try {
     const r = await api.maintRemove(paths)
@@ -294,9 +311,14 @@ async function removePaths(paths: string[], label: string): Promise<void> {
       kind: "success",
       text: `Removed ${r.removed} files (${humanSize(r.bytes_freed)})${summarizeCleanup(r.cleanup)}`,
     })
-    await load()
-    await loadState(true)
+    // Refresh state in the background (for the library grid's synced/watched
+    // percentages); not awaited so the maintenance view stays snappy.
+    loadState(true)
   } catch (e) {
+    // Rollback the optimistic state and surface the error.
+    watched.value = snapshotW
+    hanging.value = snapshotH
+    loadMaintenanceCount()
     pushToast({ kind: "error", text: (e as Error).message })
   } finally {
     removing.value = false


### PR DESCRIPTION
## Summary

Following #21 (cache + optimistic Ignore), two slownesses remained:

1. **Remove** still triggered a full reload after the cache
   invalidation forced a cold re-walk.
2. **Tab-switch back** to Synced / Watchlist / Maintenance
   re-mounted the view, triggering re-fetch and re-render.

## Fix

- **Optimistic Remove**: snapshot for rollback, drop the matching
  rows from local state immediately, decrement
  \`store.maintenanceCount\` inline. \`loadState(true)\` runs in the
  background (not awaited) so the library grid's percentages update
  without blocking the maintenance view.
- **\`<KeepAlive>\`** wraps SyncedView / WatchlistView /
  MaintenanceView in App.vue. Once loaded, they stay in memory
  across tab switches.

## Test plan

- [x] 169 backend pytest, 26 frontend vitest
- [x] No new tests needed (KeepAlive is a Vue runtime wrap; optimistic
  Remove mirrors the already-tested optimistic Ignore pattern)
- Live verify: Remove drops rows instantly; tab-switch-back is sub-100ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)