### PR TITLE
feat: read-only Syncthing integration (per-folder progress + per-device completion)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+# Synclet environment overrides. Copy to .env (gitignored) and fill in.
+# docker-compose reads .env automatically from the directory containing
+# docker-compose.dev.yml.
+
+# ── Syncthing integration (read-only) ────────────────────────────────
+# Set both to enable the Syncthing UI panel. If either is empty, the panel
+# shows "not configured" and the rest of Synclet behaves normally.
+
+# Where to reach Syncthing's REST API. Two common options:
+#   host.docker.internal: portable, works on any host that runs the Synclet
+#     stack and a host-side Syncthing (Docker Desktop maps it natively;
+#     Linux requires the extra_hosts entry in docker-compose.dev.yml,
+#     which is already in place).
+#   LAN IP: matches the Plex URL convention already in compose. Less
+#     portable but explicit. Example: http://192.168.86.5:8384
+SYNCTHING_URL=http://host.docker.internal:8384
+
+# Syncthing API key. Find it in:
+#   Syncthing GUI -> Actions -> Settings -> GUI -> API Key
+# Or from the config file:
+#   docker exec syncthing grep -oP '<apikey>\K[^<]+' /config/config.xml
+# Do NOT commit a real key. This file is the template; .env is the secret.
+SYNCTHING_API_KEY=

--- a/backend/main.py
+++ b/backend/main.py
@@ -12,7 +12,7 @@ from litestar.exceptions import NotFoundException
 from pydantic import BaseModel
 
 from common.log_utils import get_logger
-from synclet import ignored, pending, sync_ops
+from synclet import ignored, pending, sync_ops, syncthing
 from synclet.plex import fetch_art_bytes, fetch_thumb_bytes
 from synclet.resolve import resolve_url
 from synclet.scan import scan_title_detail, title_detail_to_dict
@@ -440,6 +440,20 @@ async def api_refresh() -> dict:
     return {"ok": True}
 
 
+@get("/api/syncthing/overview")
+async def api_syncthing_overview() -> dict:
+    """Read-only join of Syncthing's folder + device state.
+
+    Returns {"configured": bool, "folders": [...]}. The configured flag
+    lets the frontend distinguish "Syncthing not set up" from "Syncthing
+    set up but currently has nothing to show" without leaking env state.
+    Folders shape is documented in backend/synclet/syncthing.py.
+    """
+    if not syncthing.is_configured():
+        return {"configured": False, "folders": []}
+    return {"configured": True, "folders": await syncthing.overview()}
+
+
 app = Litestar(
     route_handlers=[
         health,
@@ -465,6 +479,7 @@ app = Litestar(
         api_scrobble,
         api_resolve,
         api_refresh,
+        api_syncthing_overview,
     ],
     cors_config=cors_config,
 )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,6 +6,7 @@ authors = [{ name = "Jacob Lasky", email = "jacob.s.lasky@gmail.com" }]
 readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
+    "httpx>=0.28.0",
     "litestar>=2.21.1",
     "pydantic>=2.13.4",
     "uvicorn>=0.47.0",

--- a/backend/synclet/config.py
+++ b/backend/synclet/config.py
@@ -88,3 +88,12 @@ SNAPSHOT_FILE = Path(
 IGNORED_FILE = Path(
     os.environ.get("SYNCLET_IGNORED_FILE", "/app/data/ignored.json"),
 )
+
+# Syncthing REST API integration (read-only). See backend/synclet/syncthing.py.
+# DO NOT supply committed defaults. The integration is opt-in; unset env vars
+# degrade the Syncthing UI surface to "not configured" without affecting the
+# rest of the app. The Plex defaults above are grandfathered (legacy homelab
+# config baked into the repo before the no-committed-secrets rule landed);
+# new secrets do not get fallbacks.
+SYNCTHING_URL = os.environ.get("SYNCTHING_URL")
+SYNCTHING_API_KEY = os.environ.get("SYNCTHING_API_KEY")

--- a/backend/synclet/syncthing.py
+++ b/backend/synclet/syncthing.py
@@ -1,0 +1,181 @@
+"""Async Syncthing REST client. READ-ONLY by design.
+
+DO NOT add PUT, POST, or DELETE methods here. Synclet observes Syncthing;
+it never mutates it. Read-only is the load-bearing invariant from issue
+#25; widening this surface breaks the contract and the security posture
+(no Synclet code path should be able to alter Syncthing folder configs,
+device pairings, or API key).
+
+Auth: Syncthing requires an X-API-Key header. The key and base URL come
+from synclet.config (SYNCTHING_URL, SYNCTHING_API_KEY). Both are env-only
+with no committed defaults; absent config degrades the UI to a "not
+configured" panel rather than crashing.
+
+Cost: /rest/db/status is documented upstream as expensive ("increasing
+CPU and RAM usage on the device, use sparingly"). The frontend polls
+/api/syncthing/overview at 8s while visible, paused otherwise. We do not
+cache server-side because the frontend's interval is the only consumer
+today; adding caching now would be premature given the small per-poll
+cost (~3 base calls + N device-completion calls for a single-folder
+homelab setup).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import httpx
+
+from synclet import config
+
+
+def is_configured() -> bool:
+    """True iff both SYNCTHING_URL and SYNCTHING_API_KEY are set."""
+    return bool(config.SYNCTHING_URL) and bool(config.SYNCTHING_API_KEY)
+
+
+async def _get(
+    client: httpx.AsyncClient,
+    path: str,
+    params: dict[str, str] | None = None,
+) -> Any:  # noqa: ANN401
+    """Single GET against Syncthing's REST API.
+
+    No retries; the caller poll-loops at 8s and any transient failure just
+    surfaces as an empty overview for one cycle.
+    """
+    headers = {"X-API-Key": config.SYNCTHING_API_KEY or ""}
+    r = await client.get(path, params=params, headers=headers, timeout=10.0)
+    r.raise_for_status()
+    return r.json()
+
+
+async def overview() -> list[dict]:
+    """Joined Syncthing view: per folder with per-device completion.
+
+    Returns an empty list when env unconfigured, Syncthing unreachable, or
+    the upstream response is malformed. Errors are swallowed because the
+    Syncthing surface is supplementary; throwing would 500 the Synclet API
+    even though the user's other workflows (sync, maintenance) are unaffected
+    by Syncthing being down.
+    """
+    if not is_configured():
+        return []
+
+    # is_configured guarantees the URL is non-None; the assert documents
+    # that for pyright and trips loudly if the guard ever drifts.
+    assert config.SYNCTHING_URL is not None  # noqa: S101
+
+    try:
+        async with httpx.AsyncClient(base_url=config.SYNCTHING_URL) as client:
+            # Three base calls fire concurrently. Folder + device configs are
+            # cheap; system/connections is needed for the online indicator.
+            folders_raw, devices_raw, conns_raw = await asyncio.gather(
+                _get(client, "/rest/config/folders"),
+                _get(client, "/rest/config/devices"),
+                _get(client, "/rest/system/connections"),
+            )
+
+            # Friendly-name lookup for devices. Syncthing's device list has
+            # entries shaped {deviceID, name, ...}; name is user-supplied
+            # and may be empty, in which case we fall back to the device ID
+            # short prefix (matches the Syncthing GUI's behavior).
+            device_name = {
+                d["deviceID"]: (d.get("name") or d["deviceID"][:7]) for d in devices_raw
+            }
+
+            # conns_raw shape: {"connections": {deviceID: {connected, ...}},
+            # "this": {deviceID: ...}, ...}. The "this" entry is the local
+            # Syncthing instance and is not a sync partner; exclude it from
+            # the device chips for each folder.
+            conns = conns_raw.get("connections", {})
+            this = conns_raw.get("this", {})
+            own_device_id = this.get("deviceID") if isinstance(this, dict) else None
+
+            result: list[dict] = []
+            for folder_cfg in folders_raw:
+                folder_id = folder_cfg["id"]
+                folder_label = folder_cfg.get("label") or folder_id
+
+                shared_device_ids = [
+                    d["deviceID"]
+                    for d in folder_cfg.get("devices", [])
+                    if d["deviceID"] != own_device_id
+                ]
+
+                # Per-folder status and per-(folder, device) completion fire
+                # concurrently. For Jake's single-folder topology with ~3
+                # devices, that is 4 parallel calls per overview poll.
+                status_task = _get(
+                    client,
+                    "/rest/db/status",
+                    params={"folder": folder_id},
+                )
+                completion_tasks = [
+                    _get(
+                        client,
+                        "/rest/db/completion",
+                        params={"folder": folder_id, "device": dev_id},
+                    )
+                    for dev_id in shared_device_ids
+                ]
+                status, *completions = await asyncio.gather(
+                    status_task,
+                    *completion_tasks,
+                )
+
+                global_bytes = status.get("globalBytes", 0)
+                in_sync_bytes = status.get("inSyncBytes", 0)
+                need_bytes = status.get("needBytes", 0)
+                state = status.get("state", "unknown")
+                # Manual percent: upstream /rest/db/status intentionally does
+                # not return one because the meaningful denominator depends
+                # on the caller (bytes vs files). Bytes match what the UI
+                # progress bar visualizes.
+                percent = (
+                    round(100.0 * in_sync_bytes / global_bytes, 1)
+                    if global_bytes
+                    else 100.0
+                )
+
+                devices_view = []
+                for dev_id, completion in zip(
+                    shared_device_ids,
+                    completions,
+                    strict=True,
+                ):
+                    conn = conns.get(dev_id, {})
+                    devices_view.append(
+                        {
+                            "device_id": dev_id,
+                            "name": device_name.get(dev_id, dev_id[:7]),
+                            "completion": round(
+                                completion.get("completion", 0.0),
+                                1,
+                            ),
+                            "need_bytes": completion.get("needBytes", 0),
+                            "connected": bool(conn.get("connected", False)),
+                            "paused": bool(conn.get("paused", False)),
+                        },
+                    )
+
+                result.append(
+                    {
+                        "folder_id": folder_id,
+                        "label": folder_label,
+                        "percent": percent,
+                        "state": state,
+                        "need_bytes": need_bytes,
+                        "in_sync_bytes": in_sync_bytes,
+                        "global_bytes": global_bytes,
+                        "devices": devices_view,
+                    },
+                )
+            return result
+    except httpx.HTTPError, KeyError, TypeError, ValueError:
+        # Network failure, malformed Syncthing response, or unreachable
+        # service: surface as empty rather than 500. The Syncthing panel
+        # treats empty as "nothing to show right now"; other Synclet
+        # functions (sync, maintenance, watchstate) are unaffected.
+        return []

--- a/backend/tests/test_syncthing.py
+++ b/backend/tests/test_syncthing.py
@@ -1,0 +1,266 @@
+"""Tests for backend/synclet/syncthing.py.
+
+We mock the module-level `_get` helper rather than reaching into httpx,
+because the join logic is what matters; the HTTP transport is a thin
+shell. Each test provides canned upstream responses keyed by REST path
+plus query params.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from synclet import config, syncthing
+
+
+def _params_key(params: dict[str, str] | None) -> str:
+    if not params:
+        return ""
+    return "&".join(f"{k}={v}" for k, v in sorted(params.items()))
+
+
+def _make_mock_get(responses: dict[tuple[str, str], Any]):
+    """Returns a coroutine that satisfies syncthing._get's signature.
+
+    Lookup is keyed by (path, sorted-query-string). Any unmocked lookup
+    raises KeyError loudly so missing fixtures fail fast.
+    """
+
+    async def mock_get(
+        _client: Any,
+        path: str,
+        params: dict[str, str] | None = None,
+    ) -> Any:
+        key = (path, _params_key(params))
+        if key not in responses:
+            msg = f"unmocked Syncthing call: {key}"
+            raise KeyError(msg)
+        return responses[key]
+
+    return mock_get
+
+
+@pytest.fixture
+def configured(monkeypatch):
+    monkeypatch.setattr(config, "SYNCTHING_URL", "http://syncthing.test:8384")
+    monkeypatch.setattr(config, "SYNCTHING_API_KEY", "test-api-key")
+
+
+@pytest.fixture
+def unconfigured(monkeypatch):
+    monkeypatch.setattr(config, "SYNCTHING_URL", None)
+    monkeypatch.setattr(config, "SYNCTHING_API_KEY", None)
+
+
+class TestIsConfigured:
+    def test_both_set(self, configured):
+        assert syncthing.is_configured() is True
+
+    def test_neither_set(self, unconfigured):
+        assert syncthing.is_configured() is False
+
+    def test_only_url_set(self, monkeypatch):
+        monkeypatch.setattr(config, "SYNCTHING_URL", "http://x:8384")
+        monkeypatch.setattr(config, "SYNCTHING_API_KEY", None)
+        assert syncthing.is_configured() is False
+
+    def test_only_key_set(self, monkeypatch):
+        monkeypatch.setattr(config, "SYNCTHING_URL", None)
+        monkeypatch.setattr(config, "SYNCTHING_API_KEY", "k")
+        assert syncthing.is_configured() is False
+
+
+class TestOverviewUnconfigured:
+    async def test_returns_empty(self, unconfigured):
+        result = await syncthing.overview()
+        assert result == []
+
+
+class TestOverviewHappyPath:
+    async def test_single_folder_two_remote_devices(self, configured, monkeypatch):
+        responses = {
+            ("/rest/config/folders", ""): [
+                {
+                    "id": "default",
+                    "label": "Media",
+                    "devices": [
+                        {"deviceID": "DEV_OWN"},
+                        {"deviceID": "DEV_LAPTOP"},
+                        {"deviceID": "DEV_PHONE"},
+                    ],
+                },
+            ],
+            ("/rest/config/devices", ""): [
+                {"deviceID": "DEV_OWN", "name": "Tower"},
+                {"deviceID": "DEV_LAPTOP", "name": "Laptop"},
+                {"deviceID": "DEV_PHONE", "name": "Phone"},
+            ],
+            ("/rest/system/connections", ""): {
+                "this": {"deviceID": "DEV_OWN"},
+                "connections": {
+                    "DEV_LAPTOP": {"connected": True, "paused": False},
+                    "DEV_PHONE": {"connected": False, "paused": False},
+                },
+            },
+            ("/rest/db/status", "folder=default"): {
+                "globalBytes": 1000,
+                "inSyncBytes": 750,
+                "needBytes": 250,
+                "state": "syncing",
+            },
+            ("/rest/db/completion", "device=DEV_LAPTOP&folder=default"): {
+                "completion": 100.0,
+                "needBytes": 0,
+            },
+            ("/rest/db/completion", "device=DEV_PHONE&folder=default"): {
+                "completion": 60.0,
+                "needBytes": 400,
+            },
+        }
+        monkeypatch.setattr(syncthing, "_get", _make_mock_get(responses))
+
+        result = await syncthing.overview()
+
+        assert len(result) == 1
+        folder = result[0]
+        assert folder["folder_id"] == "default"
+        assert folder["label"] == "Media"
+        assert folder["percent"] == 75.0
+        assert folder["in_sync_bytes"] == 750
+        assert folder["global_bytes"] == 1000
+        assert folder["need_bytes"] == 250
+        assert folder["state"] == "syncing"
+
+        # Own device is excluded; remote devices preserve insertion order.
+        assert len(folder["devices"]) == 2
+        laptop, phone = folder["devices"]
+        assert laptop["device_id"] == "DEV_LAPTOP"
+        assert laptop["name"] == "Laptop"
+        assert laptop["completion"] == 100.0
+        assert laptop["connected"] is True
+        assert laptop["paused"] is False
+        assert phone["device_id"] == "DEV_PHONE"
+        assert phone["completion"] == 60.0
+        assert phone["need_bytes"] == 400
+        assert phone["connected"] is False
+
+
+class TestOverviewEdgeCases:
+    async def test_zero_global_bytes_yields_100_percent(self, configured, monkeypatch):
+        """Empty folder is 100% in sync by convention; division-by-zero guard."""
+        responses = {
+            ("/rest/config/folders", ""): [
+                {"id": "empty", "label": "Empty", "devices": [{"deviceID": "DEV_OWN"}]},
+            ],
+            ("/rest/config/devices", ""): [{"deviceID": "DEV_OWN", "name": "Tower"}],
+            ("/rest/system/connections", ""): {
+                "this": {"deviceID": "DEV_OWN"},
+                "connections": {},
+            },
+            ("/rest/db/status", "folder=empty"): {
+                "globalBytes": 0,
+                "inSyncBytes": 0,
+                "needBytes": 0,
+                "state": "idle",
+            },
+        }
+        monkeypatch.setattr(syncthing, "_get", _make_mock_get(responses))
+
+        result = await syncthing.overview()
+        assert result[0]["percent"] == 100.0
+        assert result[0]["devices"] == []
+
+    async def test_no_folders_returns_empty(self, configured, monkeypatch):
+        responses = {
+            ("/rest/config/folders", ""): [],
+            ("/rest/config/devices", ""): [],
+            ("/rest/system/connections", ""): {
+                "this": {"deviceID": "DEV_OWN"},
+                "connections": {},
+            },
+        }
+        monkeypatch.setattr(syncthing, "_get", _make_mock_get(responses))
+
+        result = await syncthing.overview()
+        assert result == []
+
+    async def test_device_without_friendly_name_falls_back_to_id_prefix(
+        self,
+        configured,
+        monkeypatch,
+    ):
+        """Matches Syncthing GUI behavior when the user did not set a name."""
+        responses = {
+            ("/rest/config/folders", ""): [
+                {
+                    "id": "default",
+                    "label": "Media",
+                    "devices": [
+                        {"deviceID": "DEV_OWN"},
+                        {"deviceID": "ABCDEFGHIJK"},
+                    ],
+                },
+            ],
+            ("/rest/config/devices", ""): [
+                {"deviceID": "DEV_OWN", "name": "Tower"},
+                {"deviceID": "ABCDEFGHIJK", "name": ""},
+            ],
+            ("/rest/system/connections", ""): {
+                "this": {"deviceID": "DEV_OWN"},
+                "connections": {},
+            },
+            ("/rest/db/status", "folder=default"): {
+                "globalBytes": 100,
+                "inSyncBytes": 100,
+                "needBytes": 0,
+                "state": "idle",
+            },
+            ("/rest/db/completion", "device=ABCDEFGHIJK&folder=default"): {
+                "completion": 100.0,
+                "needBytes": 0,
+            },
+        }
+        monkeypatch.setattr(syncthing, "_get", _make_mock_get(responses))
+
+        result = await syncthing.overview()
+        assert result[0]["devices"][0]["name"] == "ABCDEFG"
+
+
+class TestOverviewErrorHandling:
+    async def test_unreachable_returns_empty(self, configured, monkeypatch):
+        async def raise_connect_error(*_args, **_kwargs):
+            msg = "syncthing down"
+            raise httpx.ConnectError(msg)
+
+        monkeypatch.setattr(syncthing, "_get", raise_connect_error)
+
+        result = await syncthing.overview()
+        assert result == []
+
+    async def test_http_500_returns_empty(self, configured, monkeypatch):
+        async def raise_http_error(*_args, **_kwargs):
+            request = httpx.Request("GET", "http://syncthing.test")
+            response = httpx.Response(500, request=request)
+            raise httpx.HTTPStatusError(
+                "server err", request=request, response=response
+            )
+
+        monkeypatch.setattr(syncthing, "_get", raise_http_error)
+
+        result = await syncthing.overview()
+        assert result == []
+
+    async def test_malformed_response_returns_empty(self, configured, monkeypatch):
+        """A response missing an expected key surfaces as empty, not 500."""
+        responses = {
+            ("/rest/config/folders", ""): [{"label": "Missing ID Field"}],
+            ("/rest/config/devices", ""): [],
+            ("/rest/system/connections", ""): {"connections": {}},
+        }
+        monkeypatch.setattr(syncthing, "_get", _make_mock_get(responses))
+
+        result = await syncthing.overview()
+        assert result == []

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -443,6 +443,7 @@ name = "synclet"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "httpx" },
     { name = "litestar" },
     { name = "pydantic" },
     { name = "uvicorn" },
@@ -457,6 +458,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "httpx", specifier = ">=0.28.0" },
     { name = "litestar", specifier = ">=2.21.1" },
     { name = "pydantic", specifier = ">=2.13.4" },
     { name = "uvicorn", specifier = ">=0.47.0" },

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -66,7 +66,20 @@ services:
       - SYNCLET_PLEX_URL=${SYNCLET_PLEX_URL:-http://192.168.86.183:32400}
       - SYNCLET_PLEX_TOKEN=${SYNCLET_PLEX_TOKEN:-7p79GK4xzWp6A_pyNJkw}
       - SYNCLET_THUMB_CACHE=/app/data/.thumb-cache
+      # Syncthing integration (read-only, opt-in). NO committed defaults;
+      # both come from .env (gitignored). Absent values degrade the
+      # Syncthing UI panel to "not configured" without affecting the rest
+      # of Synclet. See .env.example for the template.
+      - SYNCTHING_URL=${SYNCTHING_URL:-}
+      - SYNCTHING_API_KEY=${SYNCTHING_API_KEY:-}
       - LOG_LEVEL=INFO
+    # host.docker.internal is not auto-resolved on Linux Docker the way it
+    # is on Docker Desktop; the extra_hosts entry maps it to the Docker
+    # bridge gateway so SYNCTHING_URL=http://host.docker.internal:8384
+    # reaches a Syncthing running on the host. Users who prefer an explicit
+    # LAN IP can ignore this and set SYNCTHING_URL accordingly.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     mem_limit: 2g
     memswap_limit: 2g
     develop:

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -8,6 +8,7 @@ import DetailDrawer from "./components/DetailDrawer.vue"
 import SyncedView from "./components/SyncedView.vue"
 import WatchlistView from "./components/WatchlistView.vue"
 import MaintenanceView from "./components/MaintenanceView.vue"
+import SyncthingView from "./components/SyncthingView.vue"
 import LinkPasteModal from "./components/LinkPasteModal.vue"
 import JobToasts from "./components/JobToasts.vue"
 import { api } from "./api"
@@ -84,6 +85,7 @@ window.addEventListener("keydown", onKeydown)
         <SyncedView      v-if="store.tab === 'synced'" />
         <WatchlistView   v-else-if="store.tab === 'watchlist'" />
         <MaintenanceView v-else-if="store.tab === 'maintenance'" />
+        <SyncthingView   v-else-if="store.tab === 'syncthing'" />
       </KeepAlive>
     </main>
 

--- a/frontend/src/SyncthingView.test.ts
+++ b/frontend/src/SyncthingView.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { flushPromises, mount } from "@vue/test-utils"
+import SyncthingView from "./components/SyncthingView.vue"
+
+// Stub the api module so each test controls the wire data and we can
+// count poll cycles.
+const mockOverview = vi.fn()
+vi.mock("./api", () => ({
+  api: {
+    syncthingOverview: () => mockOverview(),
+  },
+}))
+
+const HAPPY_OVERVIEW = {
+  configured: true,
+  folders: [
+    {
+      folder_id: "default",
+      label: "Media",
+      percent: 75,
+      state: "syncing",
+      need_bytes: 250,
+      in_sync_bytes: 750,
+      global_bytes: 1000,
+      devices: [
+        {
+          device_id: "DEV_LAPTOP",
+          name: "Laptop",
+          completion: 100,
+          need_bytes: 0,
+          connected: true,
+          paused: false,
+        },
+        {
+          device_id: "DEV_PHONE",
+          name: "Phone",
+          completion: 60,
+          need_bytes: 400,
+          connected: false,
+          paused: false,
+        },
+      ],
+    },
+  ],
+}
+
+describe("SyncthingView", () => {
+  beforeEach(() => {
+    mockOverview.mockReset()
+  })
+
+  afterEach(() => {
+    // Belt-and-suspenders: tests that opted into fake timers must restore
+    // real ones before the next test runs, even if they threw mid-flight.
+    vi.useRealTimers()
+  })
+
+  describe("render states", () => {
+    it("shows the not-configured panel when backend reports configured=false", async () => {
+      mockOverview.mockResolvedValue({ configured: false, folders: [] })
+      const wrapper = mount(SyncthingView)
+      await flushPromises()
+      expect(wrapper.text()).toContain("Syncthing not configured")
+      expect(wrapper.text()).toContain("SYNCTHING_URL")
+      expect(wrapper.text()).toContain("SYNCTHING_API_KEY")
+    })
+
+    it("renders folder rows + per-device chips when populated", async () => {
+      mockOverview.mockResolvedValue(HAPPY_OVERVIEW)
+      const wrapper = mount(SyncthingView)
+      await flushPromises()
+
+      const text = wrapper.text()
+      expect(text).toContain("Media")
+      expect(text).toContain("75%")
+      expect(text).toContain("syncing")
+
+      // Both devices visible with their completion and state tags.
+      expect(text).toContain("Laptop")
+      expect(text).toContain("100%")
+      expect(text).toContain("in sync")
+      expect(text).toContain("Phone")
+      expect(text).toContain("60%")
+      expect(text).toContain("offline")
+    })
+
+    it("shows the empty-folders message when configured but Syncthing has no folders", async () => {
+      mockOverview.mockResolvedValue({ configured: true, folders: [] })
+      const wrapper = mount(SyncthingView)
+      await flushPromises()
+      expect(wrapper.text()).toContain("no folders are configured")
+    })
+
+    it("shows the no-remote-devices message for a folder without sharers", async () => {
+      mockOverview.mockResolvedValue({
+        configured: true,
+        folders: [
+          {
+            ...HAPPY_OVERVIEW.folders[0],
+            devices: [],
+          },
+        ],
+      })
+      const wrapper = mount(SyncthingView)
+      await flushPromises()
+      expect(wrapper.text()).toContain("No remote devices share this folder")
+    })
+  })
+
+  describe("polling cadence", () => {
+    it("polls the overview endpoint every 8s while mounted", async () => {
+      mockOverview.mockResolvedValue(HAPPY_OVERVIEW)
+      vi.useFakeTimers()
+
+      const wrapper = mount(SyncthingView)
+      // Initial load fires synchronously from onMounted (returns a Promise
+      // we need to flush). Do NOT use vi.runOnlyPendingTimersAsync here:
+      // it fires the setInterval's first tick prematurely.
+      await flushPromises()
+      expect(mockOverview).toHaveBeenCalledTimes(1)
+
+      // Just under 8s: no new call yet.
+      await vi.advanceTimersByTimeAsync(7000)
+      expect(mockOverview).toHaveBeenCalledTimes(1)
+
+      // Crossing the 8s boundary fires the next poll.
+      await vi.advanceTimersByTimeAsync(1500)
+      expect(mockOverview).toHaveBeenCalledTimes(2)
+
+      // Another full 8s cycle.
+      await vi.advanceTimersByTimeAsync(8000)
+      expect(mockOverview).toHaveBeenCalledTimes(3)
+
+      wrapper.unmount()
+    })
+
+    it("stops polling after unmount", async () => {
+      mockOverview.mockResolvedValue(HAPPY_OVERVIEW)
+      vi.useFakeTimers()
+
+      const wrapper = mount(SyncthingView)
+      await flushPromises()
+      expect(mockOverview).toHaveBeenCalledTimes(1)
+
+      wrapper.unmount()
+
+      // After unmount, no further polls should land regardless of how
+      // much time passes.
+      await vi.advanceTimersByTimeAsync(30_000)
+      expect(mockOverview).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -14,6 +14,7 @@ import type {
   ScrobbleScope,
   StateBundle,
   SyncedEntry,
+  SyncthingOverview,
   TitleDetail,
   WatchedFiles,
   WatchlistEntry,
@@ -92,6 +93,8 @@ export const api = {
       method: "POST",
       body: JSON.stringify(body),
     }),
+
+  syncthingOverview: () => json<SyncthingOverview>(`/api/syncthing/overview`),
 }
 
 export interface ScrobbleBody {

--- a/frontend/src/components/SyncthingView.vue
+++ b/frontend/src/components/SyncthingView.vue
@@ -1,0 +1,250 @@
+<script setup lang="ts">
+import { onActivated, onDeactivated, onMounted, onUnmounted, ref } from "vue"
+import { api } from "../api"
+import type { SyncthingFolder } from "../types"
+import { humanSize } from "../store"
+
+// Poll cadence matches the upstream guidance for /rest/db/status:
+// "expensive call, use sparingly". Bumping below 8s without an upstream
+// changelog update is the bug; bumping above is fine UX-wise.
+const POLL_INTERVAL_MS = 8000
+
+const configured = ref(true)
+const folders = ref<SyncthingFolder[]>([])
+const loading = ref(true)
+const error = ref("")
+let pollTimer: ReturnType<typeof setInterval> | null = null
+
+async function load(): Promise<void> {
+  error.value = ""
+  try {
+    const r = await api.syncthingOverview()
+    configured.value = r.configured
+    folders.value = r.folders
+  } catch (e) {
+    error.value = (e as Error).message
+  } finally {
+    loading.value = false
+  }
+}
+
+function startPolling(): void {
+  if (pollTimer != null) return
+  load()
+  pollTimer = setInterval(load, POLL_INTERVAL_MS)
+}
+
+function stopPolling(): void {
+  if (pollTimer != null) {
+    clearInterval(pollTimer)
+    pollTimer = null
+  }
+}
+
+// onActivated handles tab returns under KeepAlive (App.vue wraps non-library
+// views in KeepAlive). onMounted is the fallback for direct mounting (vitest
+// mounts components without KeepAlive, so onActivated never fires there).
+// Both routes funnel through startPolling, which is idempotent against
+// double-fire.
+onActivated(startPolling)
+onMounted(startPolling)
+onDeactivated(stopPolling)
+onUnmounted(stopPolling)
+</script>
+
+<template>
+  <div class="view fade-in">
+    <div v-if="!configured" class="info">
+      <p><strong>Syncthing not configured.</strong></p>
+      <p class="dim">
+        Set <code>SYNCTHING_URL</code> and <code>SYNCTHING_API_KEY</code> in
+        your <code>.env</code> file to enable this panel. See
+        <code>.env.example</code> for the template.
+      </p>
+    </div>
+    <div v-else-if="loading && folders.length === 0" class="info">
+      Loading Syncthing state…
+    </div>
+    <div v-else-if="error" class="info err">{{ error }}</div>
+    <template v-else>
+      <div v-if="folders.length === 0" class="info">
+        <p>Connected to Syncthing, but no folders are configured.</p>
+      </div>
+      <div v-else class="list">
+        <div
+          v-for="folder in folders"
+          :key="folder.folder_id"
+          class="folder"
+        >
+          <div class="folder-header">
+            <span class="folder-label">{{ folder.label }}</span>
+            <span class="folder-state" :class="`state-${folder.state}`">
+              {{ folder.state }}
+            </span>
+            <span class="folder-percent">{{ folder.percent }}%</span>
+          </div>
+          <div class="folder-bytes dim">
+            {{ humanSize(folder.in_sync_bytes) }} of
+            {{ humanSize(folder.global_bytes) }} in sync
+            <span v-if="folder.need_bytes > 0">
+              · {{ humanSize(folder.need_bytes) }} pending
+            </span>
+          </div>
+          <div class="bar">
+            <div class="bar-fill" :style="{ width: folder.percent + '%' }" />
+          </div>
+
+          <div v-if="folder.devices.length > 0" class="devices">
+            <div
+              v-for="dev in folder.devices"
+              :key="dev.device_id"
+              class="device"
+              :class="{
+                offline: !dev.connected && !dev.paused,
+                paused: dev.paused,
+                'in-sync': dev.connected && !dev.paused && dev.completion >= 100,
+              }"
+            >
+              <span class="device-name">{{ dev.name }}</span>
+              <span class="device-completion">{{ dev.completion }}%</span>
+              <span v-if="dev.paused" class="device-tag">paused</span>
+              <span v-else-if="!dev.connected" class="device-tag">offline</span>
+              <span v-else-if="dev.need_bytes > 0" class="device-tag">
+                {{ humanSize(dev.need_bytes) }} behind
+              </span>
+              <span v-else class="device-tag ok">in sync</span>
+            </div>
+          </div>
+          <div v-else class="info dim no-devices">
+            No remote devices share this folder.
+          </div>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.view {
+  padding: 1rem;
+  overflow-y: auto;
+}
+.info {
+  padding: 1.5rem 1rem;
+  text-align: center;
+  color: var(--fg-muted);
+}
+.info.err {
+  color: var(--accent-danger, #b04040);
+}
+.info code {
+  background: var(--bg-elev-2);
+  padding: 0.1em 0.4em;
+  border-radius: 3px;
+  font-size: 0.9em;
+}
+.dim {
+  color: var(--fg-muted);
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.folder {
+  background: var(--bg-elev-1);
+  border-radius: 8px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.folder-header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+.folder-label {
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+.folder-state {
+  padding: 1px 8px;
+  border-radius: 10px;
+  background: var(--bg-elev-2);
+  color: var(--fg-muted);
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.folder-state.state-syncing {
+  background: var(--accent-action, #4080c0);
+  color: #fff;
+}
+.folder-state.state-idle {
+  background: var(--bg-elev-2);
+}
+.folder-state.state-error,
+.folder-state.state-unknown {
+  background: var(--accent-danger, #b04040);
+  color: #fff;
+}
+.folder-percent {
+  margin-left: auto;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.bar {
+  height: 6px;
+  background: var(--bg-elev-2);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.bar-fill {
+  height: 100%;
+  background: var(--accent-action, #4080c0);
+  transition: width 0.4s ease;
+}
+
+.devices {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-top: 0.25rem;
+}
+.device {
+  display: flex;
+  align-items: baseline;
+  gap: 0.65rem;
+  padding: 0.35rem 0.6rem;
+  background: var(--bg-elev-2);
+  border-radius: 6px;
+  font-size: 0.92rem;
+}
+.device.offline { opacity: 0.5; }
+.device.paused { opacity: 0.65; font-style: italic; }
+.device-name {
+  font-weight: 500;
+  min-width: 5rem;
+}
+.device-completion {
+  font-variant-numeric: tabular-nums;
+  color: var(--fg-muted);
+  min-width: 3.5rem;
+}
+.device-tag {
+  margin-left: auto;
+  font-size: 0.78rem;
+  color: var(--fg-muted);
+}
+.device-tag.ok {
+  color: var(--accent-success, #4ca44c);
+}
+.no-devices {
+  font-size: 0.88rem;
+  padding: 0.5rem;
+}
+</style>

--- a/frontend/src/components/TabBar.vue
+++ b/frontend/src/components/TabBar.vue
@@ -9,6 +9,7 @@ const tabs: { id: Tab; label: string }[] = [
   { id: "synced",      label: "Synced" },
   { id: "watchlist",   label: "Watchlist" },
   { id: "maintenance", label: "Maintenance" },
+  { id: "syncthing",   label: "Syncthing" },
 ]
 </script>
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -145,7 +145,32 @@ export interface ResolveResult {
   via?: string
 }
 
-export type Tab = "library" | "synced" | "watchlist" | "maintenance"
+export type Tab = "library" | "synced" | "watchlist" | "maintenance" | "syncthing"
+
+export interface SyncthingDevice {
+  device_id: string
+  name: string
+  completion: number
+  need_bytes: number
+  connected: boolean
+  paused: boolean
+}
+
+export interface SyncthingFolder {
+  folder_id: string
+  label: string
+  percent: number
+  state: string
+  need_bytes: number
+  in_sync_bytes: number
+  global_bytes: number
+  devices: SyncthingDevice[]
+}
+
+export interface SyncthingOverview {
+  configured: boolean
+  folders: SyncthingFolder[]
+}
 
 export interface PendingEpisode {
   season: number


### PR DESCRIPTION
## Summary

Closes #25.

Synclet now surfaces Syncthing's view of the world: per-folder progress
(bytes / state / percent) plus per-device completion (so the UI shows
whether the laptop has actually pulled what Synclet copied locally).
Read-only by design; Synclet observes Syncthing, never mutates it.

## What landed

- **Backend** (`3616ba8`):
  - `backend/synclet/syncthing.py`, new async httpx client. GET-only by
    design; `DO NOT add PUT/POST` invariant is documented in the module
    docstring.
  - `GET /api/syncthing/overview`, new flat route in `main.py`.
  - Env config (`SYNCTHING_URL`, `SYNCTHING_API_KEY`), no committed
    defaults. Plex's grandfathered default is explicitly called out as
    not a precedent in the config comment.
  - 12 mock-based tests (happy path + edge cases + error handling).
- **Frontend** (`e6f19e2`):
  - New `SyncthingView` tab. Folder rows with progress bar and byte
    counts; device chips with per-device completion, connected /
    paused / in-sync states.
  - Polls `/api/syncthing/overview` every 8s. `onActivated` /
    `onDeactivated` start/stop the timer so polling pauses when the
    tab isn't visible (respects upstream "expensive call, use
    sparingly" guidance for `/rest/db/status`).
  - 6 vitest cases (4 render states + 8s cadence verification + unmount
    cleanup).
- **Config**:
  - `.env.example` template with both `host.docker.internal` and LAN-IP
    URL options documented.
  - `docker-compose.dev.yml` passes the new env vars through (no
    defaults) and adds `extra_hosts: host.docker.internal:host-gateway`
    so the default URL resolves on Linux Docker.

## Live verification (Phase 2.7)

Wire shape verified end-to-end against the real Syncthing on Tower:

\`\`\`json
[
  {
    "folder_id": "fhvvh-nb4mr",
    "label": "media",
    "percent": 100.0,
    "state": "idle",
    "need_bytes": 0,
    "in_sync_bytes": 168075208735,
    "global_bytes": 168075208735,
    "devices": [
      {"device_id": "H23KR7D-...", "name": "tower",         "completion": 95,  "connected": false, "paused": false, "need_bytes": 0},
      {"device_id": "LRZ2AL5-...", "name": "JakePixelTablet","completion": 100, "connected": false, "paused": false, "need_bytes": 0}
    ]
  }
]
\`\`\`

## Phase 5.5 visual artifact: PENDING-USER-CONFIRMATION

Vitest cases render-test against canned JSON whose shape I authored
myself. The wire shape was live-verified (above) and matches the canned
shape used in tests, but no browser screenshot of the rendered UI has
been captured. Pocket-dev has no Playwright and redeploying the running
Synclet stack against this branch was out of scope for the PR itself.

To visually confirm:
1. `git switch feat/syncthing-readonly-25`
2. Copy `.env.example` to `.env` and fill in `SYNCTHING_API_KEY`.
3. `docker compose -f docker-compose.dev.yml up -d --build backend`
4. Open http://localhost:1313 and click the Syncthing tab.

## Out of scope, filed as follow-ups

- #28 (`docs(ui): update 'synced' labels post-#25`): the existing
  "synced" labels in `SyncedView` and `TitleCard` mean "in the local
  sync folder," which becomes a half-truth once Syncthing visibility
  is live. Filed as a separate issue to keep this PR's blast radius
  bounded to the new feature surface.
- #8 (pre-existing): `pnpm build` fails on main with type errors in
  `DetailDrawer.vue`, `JobToasts.vue`, and `vite.config.ts` (missing
  `@types/node`). My touched files are clean; the pre-existing
  failures are unchanged.
- #9 (pre-existing): repo-wide ruff debt (~840 errors). My new files
  match the existing codebase's lint posture; new code follows the
  same patterns the rest of the suite uses.

## Test plan

- [x] Backend: `uv run pytest` (181/181 green, 12 new)
- [x] Backend: `uv run pyright` clean on new files
- [x] Frontend: `pnpm test` (32/32 green, 6 new)
- [x] Live verification of the wire shape against the running Syncthing
      on Tower
- [ ] Visual confirmation of the rendered UI in a browser
      (PENDING-USER-CONFIRMATION)