### PR TITLE
chore(frontend): wire ESLint + Prettier, fix surfaced type holes

### DIFF
--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -1,5 +1,6 @@
 # Dependency directories
 node_modules/
+.pnpm-store/
 dist/
 coverage/
 .build/

--- a/frontend/eslint.config.cjs
+++ b/frontend/eslint.config.cjs
@@ -1,16 +1,18 @@
-// eslint.config.cjs
+// Flat config. ESLint v9+ syntax.
+//
+// Curated rule set, NOT exhaustive. The goal here is the same as the backend
+// ruff config: catch real bugs and contract drift, enforce a single format,
+// avoid noise that fights idiomatic Vue 3 + TypeScript code. If a rule shows
+// up as the firehose against this codebase, the answer is to drop the rule,
+// not blanket-disable callers.
 
 const vue = require("eslint-plugin-vue")
-const ts = require("@typescript-eslint/eslint-plugin")
-const prettier = require("eslint-plugin-prettier")
-const vueRecommended = require("eslint-plugin-vue/lib/configs/vue3-recommended")
-const tsRecommended = require("@typescript-eslint/eslint-plugin").configs
-    .recommended
-const prettierRecommended = require("eslint-plugin-prettier").configs
-    .recommended
+const tsPlugin = require("@typescript-eslint/eslint-plugin")
+const tsParser = require("@typescript-eslint/parser")
+const vueParser = require("vue-eslint-parser")
+const prettierRecommended = require("eslint-plugin-prettier/recommended")
 
 const config = [
-    // Global ignores (applies to everything)
     {
         ignores: [
             "node_modules/",
@@ -18,80 +20,96 @@ const config = [
             "public/",
             "*.config.js",
             "vite.config.ts",
+            "vitest.config.ts",
         ],
     },
 
-    // TypeScript and Vue Single File Components
+    // Vue + TypeScript sources. Type-aware lint requires tsconfig.eslint.json.
+    ...vue.configs["flat/recommended"],
     {
         files: ["**/*.ts", "**/*.vue"],
         languageOptions: {
-            parser: require("vue-eslint-parser"),
+            parser: vueParser,
             parserOptions: {
-                parser: require("@typescript-eslint/parser"),
+                parser: tsParser,
                 ecmaVersion: 2021,
                 sourceType: "module",
                 project: "./tsconfig.eslint.json",
+                tsconfigRootDir: __dirname,
                 extraFileExtensions: [".vue"],
             },
         },
         plugins: {
-            vue,
-            prettier,
-            "@typescript-eslint": ts,
+            "@typescript-eslint": tsPlugin,
         },
         rules: {
-            ...vueRecommended.rules,
-            ...tsRecommended.rules,
-            ...prettierRecommended.rules,
-            "prettier/prettier": "error",
+            ...tsPlugin.configs.recommended.rules,
 
-            // TypeScript type safety rules - surface type errors as lint errors
+            // Type-safety rules that catch real footguns in TS+Vue glue code.
+            // Each chosen because it would have caught a class of bug we've
+            // hit in the surrounding codebases, not for completeness.
             "@typescript-eslint/no-unsafe-member-access": "error",
             "@typescript-eslint/no-unsafe-assignment": "warn",
             "@typescript-eslint/no-unsafe-call": "warn",
             "@typescript-eslint/no-unsafe-return": "error",
             "@typescript-eslint/no-unsafe-argument": "error",
             "@typescript-eslint/no-explicit-any": "error",
-            "@typescript-eslint/strict-boolean-expressions": "error",
             "@typescript-eslint/no-unnecessary-type-assertion": "error",
             "@typescript-eslint/prefer-as-const": "error",
             "@typescript-eslint/no-non-null-assertion": "error",
-
-            // Catch type assignment errors
             "@typescript-eslint/no-misused-new": "error",
             "@typescript-eslint/no-this-alias": "error",
             "@typescript-eslint/prefer-readonly": "error",
+
+            // unused-vars: allow `_` prefix to silence (matches Vue conventions
+            // around destructured props the template doesn't reference).
+            "@typescript-eslint/no-unused-vars": [
+                "error",
+                {
+                    argsIgnorePattern: "^_",
+                    varsIgnorePattern: "^_",
+                    caughtErrorsIgnorePattern: "^_",
+                },
+            ],
+
+            // Vue refinements that fire in idiomatic Vue 3 SFCs.
+            // The recommended set wants kebab-case events and a few component
+            // formatting rules that prettier already owns. Trim the overlap.
+            "vue/multi-word-component-names": "off",
         },
     },
 
-    // JavaScript config files (e.g., eslint.config.cjs)
+    // Test files: relax the non-null assertion ban. Vitest's idiomatic pattern
+    // is `expect(x).toBeDefined()` followed by `x!.foo` — the assertion has
+    // already narrowed runtime, the `!` just shuts up TS. Forcing a second
+    // narrowing layer (`if (!x) throw`) is noise in test code.
+    {
+        files: ["**/*.test.ts"],
+        rules: {
+            "@typescript-eslint/no-non-null-assertion": "off",
+        },
+    },
+
+    // Loose JS/CJS files (this config + any future scripts). No type-aware
+    // rules, since TS-eslint without parser metadata throws.
     {
         files: ["**/*.js", "**/*.cjs"],
         languageOptions: {
             ecmaVersion: 2021,
-            sourceType: "module",
+            sourceType: "commonjs",
             globals: {
                 console: "readonly",
                 module: "readonly",
                 require: "readonly",
                 __dirname: "readonly",
+                process: "readonly",
             },
         },
-        plugins: {
-            prettier,
-            "@typescript-eslint": ts,
-        },
-        rules: {
-            ...prettierRecommended.rules,
-            "prettier/prettier": "error",
-        },
     },
+
+    // Prettier last so it wins formatting conflicts. The /recommended bundle
+    // also turns off eslint formatting rules that overlap with prettier.
+    prettierRecommended,
 ]
 
-// Downgrade to warnings if ONLY_WARN=true (for development)
-if (process.env.ONLY_WARN === "true") {
-    const onlyWarn = require("eslint-plugin-only-warn")
-    module.exports = onlyWarn(config)
-} else {
-    module.exports = config
-}
+module.exports = config

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,14 +1,17 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta name="color-scheme" content="dark" />
-    <meta name="theme-color" content="#0c0e12" />
-    <title>Synclet</title>
-  </head>
-  <body>
-    <div id="app"></div>
-    <script type="module" src="/src/main.ts"></script>
-  </body>
+    <head>
+        <meta charset="UTF-8" />
+        <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+        />
+        <meta name="color-scheme" content="dark" />
+        <meta name="theme-color" content="#0c0e12" />
+        <title>Synclet</title>
+    </head>
+    <body>
+        <div id="app"></div>
+        <script type="module" src="/src/main.ts"></script>
+    </body>
 </html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,26 +1,37 @@
 {
-  "name": "synclet-frontend",
-  "private": true,
-  "version": "0.1.0",
-  "type": "module",
-  "scripts": {
-    "dev": "vite",
-    "build": "vue-tsc -b && vite build",
-    "preview": "vite preview",
-    "test": "vitest run",
-    "test:watch": "vitest"
-  },
-  "dependencies": {
-    "vue": "^3.5.34"
-  },
-  "devDependencies": {
-    "@vitejs/plugin-vue": "^6.0.7",
-    "@vue/test-utils": "^2.4.10",
-    "@vue/tsconfig": "^0.8.1",
-    "happy-dom": "^15.11.0",
-    "typescript": "^6.0.3",
-    "vite": "^8.0.13",
-    "vitest": "^4.0.5",
-    "vue-tsc": "^3.3.0"
-  }
+    "name": "synclet-frontend",
+    "private": true,
+    "version": "0.1.0",
+    "type": "module",
+    "scripts": {
+        "dev": "vite",
+        "build": "vue-tsc -b && vite build",
+        "preview": "vite preview",
+        "test": "vitest run",
+        "test:watch": "vitest",
+        "lint": "eslint . && prettier --check .",
+        "format": "prettier --write . && eslint --fix ."
+    },
+    "dependencies": {
+        "vue": "^3.5.34"
+    },
+    "devDependencies": {
+        "@types/node": "^25.9.1",
+        "@typescript-eslint/eslint-plugin": "^8.59.4",
+        "@typescript-eslint/parser": "^8.59.4",
+        "@vitejs/plugin-vue": "^6.0.7",
+        "@vue/test-utils": "^2.4.10",
+        "@vue/tsconfig": "^0.8.1",
+        "eslint": "^10.4.0",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-prettier": "^5.5.5",
+        "eslint-plugin-vue": "^10.9.1",
+        "happy-dom": "^15.11.0",
+        "prettier": "^3.8.3",
+        "typescript": "^6.0.3",
+        "vite": "^8.0.13",
+        "vitest": "^4.0.5",
+        "vue-eslint-parser": "^10.4.0",
+        "vue-tsc": "^3.3.0"
+    }
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -12,27 +12,54 @@ importers:
         specifier: ^3.5.34
         version: 3.5.34(typescript@6.0.3)
     devDependencies:
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.1
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.59.4
+        version: 8.59.4(@typescript-eslint/parser@8.59.4(eslint@10.4.0)(typescript@6.0.3))(eslint@10.4.0)(typescript@6.0.3)
+      '@typescript-eslint/parser':
+        specifier: ^8.59.4
+        version: 8.59.4(eslint@10.4.0)(typescript@6.0.3)
       '@vitejs/plugin-vue':
         specifier: ^6.0.7
-        version: 6.0.7(vite@8.0.13)(vue@3.5.34(typescript@6.0.3))
+        version: 6.0.7(vite@8.0.13(@types/node@25.9.1))(vue@3.5.34(typescript@6.0.3))
       '@vue/test-utils':
         specifier: ^2.4.10
         version: 2.4.10(@vue/compiler-dom@3.5.34)(@vue/server-renderer@3.5.34(vue@3.5.34(typescript@6.0.3)))(vue@3.5.34(typescript@6.0.3))
       '@vue/tsconfig':
         specifier: ^0.8.1
         version: 0.8.1(typescript@6.0.3)(vue@3.5.34(typescript@6.0.3))
+      eslint:
+        specifier: ^10.4.0
+        version: 10.4.0
+      eslint-config-prettier:
+        specifier: ^10.1.8
+        version: 10.1.8(eslint@10.4.0)
+      eslint-plugin-prettier:
+        specifier: ^5.5.5
+        version: 5.5.5(eslint-config-prettier@10.1.8(eslint@10.4.0))(eslint@10.4.0)(prettier@3.8.3)
+      eslint-plugin-vue:
+        specifier: ^10.9.1
+        version: 10.9.1(@typescript-eslint/parser@8.59.4(eslint@10.4.0)(typescript@6.0.3))(eslint@10.4.0)(vue-eslint-parser@10.4.0(eslint@10.4.0))
       happy-dom:
         specifier: ^15.11.0
         version: 15.11.7
+      prettier:
+        specifier: ^3.8.3
+        version: 3.8.3
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vite:
         specifier: ^8.0.13
-        version: 8.0.13
+        version: 8.0.13(@types/node@25.9.1)
       vitest:
         specifier: ^4.0.5
-        version: 4.1.6(happy-dom@15.11.7)(vite@8.0.13)
+        version: 4.1.6(@types/node@25.9.1)(happy-dom@15.11.7)(vite@8.0.13(@types/node@25.9.1))
+      vue-eslint-parser:
+        specifier: ^10.4.0
+        version: 10.4.0(eslint@10.4.0)
       vue-tsc:
         specifier: ^3.3.0
         version: 3.3.0(typescript@6.0.3)
@@ -65,6 +92,56 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.23.5':
+    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/config-helpers@0.6.0':
+    resolution: {integrity: sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/core@1.2.1':
+    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/object-schema@3.0.5':
+    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/plugin-kit@0.7.1':
+    resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -87,6 +164,10 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@pkgr/core@0.2.9':
+    resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
   '@rolldown/binding-android-arm64@1.0.1':
     resolution: {integrity: sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==}
@@ -198,8 +279,76 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/esrecurse@4.3.1':
+    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@25.9.1':
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
+
+  '@typescript-eslint/eslint-plugin@8.59.4':
+    resolution: {integrity: sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.59.4
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.59.4':
+    resolution: {integrity: sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.59.4':
+    resolution: {integrity: sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.59.4':
+    resolution: {integrity: sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.59.4':
+    resolution: {integrity: sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.59.4':
+    resolution: {integrity: sha512-uonTuPAAKr9XaBGqJ3LjYTh72zy5DyGesljO9gtmk/eFW0W1fRHjnwVYKB35Lm8d5Q5CluEW3gPHjTvZTmgrfA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.59.4':
+    resolution: {integrity: sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.59.4':
+    resolution: {integrity: sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.59.4':
+    resolution: {integrity: sha512-cYXeNAUsG4lJo5dbc1FcKm+JwIWrj1/UpTORsC6tGMjEZ81DYcvIr9/ueikhMa/Y/gDQYGp+YX9/xQrXje5BJw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.59.4':
+    resolution: {integrity: sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@vitejs/plugin-vue@6.0.7':
     resolution: {integrity: sha512-km+p+XdSz9Sxm5rqUbqcSfZYaAniKxWBj1KURl+Jr7UaPvvX7BmaWMdP69I5rrFDeQGyxAG7NXdc57vz+snhWg==}
@@ -303,6 +452,19 @@ packages:
     resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
   alien-signals@3.2.1:
     resolution: {integrity: sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==}
 
@@ -329,8 +491,19 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -357,8 +530,25 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -389,15 +579,107 @@ packages:
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-config-prettier@10.1.8:
+    resolution: {integrity: sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==}
+    hasBin: true
+    peerDependencies:
+      eslint: '>=7.0.0'
+
+  eslint-plugin-prettier@5.5.5:
+    resolution: {integrity: sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      '@types/eslint': '>=8.0.0'
+      eslint: '>=8.0.0'
+      eslint-config-prettier: '>= 7.0.0 <10.0.0 || >=10.1.0'
+      prettier: '>=3.0.0'
+    peerDependenciesMeta:
+      '@types/eslint':
+        optional: true
+      eslint-config-prettier:
+        optional: true
+
+  eslint-plugin-vue@10.9.1:
+    resolution: {integrity: sha512-cHB0Tf4Duvzwecwd/AqWzZvF/QszE13BhjVUpVXWCy9AeMR5GjkAjP3i85vqgLgOuTmkHR1OJ5oMeqLHtuw8zg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@stylistic/eslint-plugin': ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
+      '@typescript-eslint/parser': ^7.0.0 || ^8.0.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      vue-eslint-parser: ^10.3.0
+    peerDependenciesMeta:
+      '@stylistic/eslint-plugin':
+        optional: true
+      '@typescript-eslint/parser':
+        optional: true
+
+  eslint-scope@9.1.2:
+    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@10.4.0:
+    resolution: {integrity: sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@11.2.0:
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-diff@1.3.0:
+    resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -408,6 +690,21 @@ packages:
       picomatch:
         optional: true
 
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
@@ -416,6 +713,10 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
@@ -426,12 +727,32 @@ packages:
     resolution: {integrity: sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==}
     engines: {node: '>=18.0.0'}
 
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
 
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -447,6 +768,22 @@ packages:
   js-cookie@3.0.7:
     resolution: {integrity: sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==}
     engines: {node: '>=20'}
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -522,11 +859,19 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
 
   minimatch@9.0.9:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
@@ -536,6 +881,9 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
@@ -544,19 +892,41 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
   nopt@7.2.1:
     resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     hasBin: true
 
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -576,12 +946,33 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  postcss-selector-parser@7.1.1:
+    resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
+    engines: {node: '>=4'}
+
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  prettier-linter-helpers@1.0.1:
+    resolution: {integrity: sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==}
+    engines: {node: '>=6.0.0'}
+
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+    engines: {node: '>=14'}
+    hasBin: true
+
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   rolldown@1.0.1:
     resolution: {integrity: sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==}
@@ -634,6 +1025,10 @@ packages:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
+  synckit@0.11.12:
+    resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -649,13 +1044,32 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
 
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vite@8.0.13:
     resolution: {integrity: sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==}
@@ -747,6 +1161,12 @@ packages:
   vue-component-type-helpers@3.3.0:
     resolution: {integrity: sha512-vwR8DDsBysI9NWXa0okPFpCcW+BUC3sPTuLBNo1faMzw4QWMFd+3/lFYFu29ZN0q+8UReXWJHEYesC9dcXYCLg==}
 
+  vue-eslint-parser@10.4.0:
+    resolution: {integrity: sha512-Vxi9pJdbN3ZnVGLODVtZ7y4Y2kzAAE2Cm0CZ3ZDRvydVYxZ6VrnBhLikBsRS+dpwj4Jv4UCv21PTEwF5rQ9WXg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+
   vue-tsc@3.3.0:
     resolution: {integrity: sha512-kY8RcoTOENASi0P1GLPvJgA2+hoGF+t8We1UGgmnAb1r/GjTUMSE3zz+WGfjPORZNnBHdAt67sVPhBLXWunkeg==}
     hasBin: true
@@ -779,6 +1199,10 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -786,6 +1210,14 @@ packages:
   wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
+
+  xml-name-validator@4.0.0:
+    resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
+    engines: {node: '>=12'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
 
 snapshots:
 
@@ -818,6 +1250,52 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.4.0)':
+    dependencies:
+      eslint: 10.4.0
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.23.5':
+    dependencies:
+      '@eslint/object-schema': 3.0.5
+      debug: 4.4.3
+      minimatch: 10.2.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.6.0':
+    dependencies:
+      '@eslint/core': 1.2.1
+
+  '@eslint/core@1.2.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/object-schema@3.0.5': {}
+
+  '@eslint/plugin-kit@0.7.1':
+    dependencies:
+      '@eslint/core': 1.2.1
+      levn: 0.4.1
+
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -842,6 +1320,8 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@pkgr/core@0.2.9': {}
 
   '@rolldown/binding-android-arm64@1.0.1':
     optional: true
@@ -908,12 +1388,111 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/esrecurse@4.3.1': {}
+
   '@types/estree@1.0.9': {}
 
-  '@vitejs/plugin-vue@6.0.7(vite@8.0.13)(vue@3.5.34(typescript@6.0.3))':
+  '@types/json-schema@7.0.15': {}
+
+  '@types/node@25.9.1':
+    dependencies:
+      undici-types: 7.24.6
+
+  '@typescript-eslint/eslint-plugin@8.59.4(@typescript-eslint/parser@8.59.4(eslint@10.4.0)(typescript@6.0.3))(eslint@10.4.0)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.59.4(eslint@10.4.0)(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.59.4
+      '@typescript-eslint/type-utils': 8.59.4(eslint@10.4.0)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.4(eslint@10.4.0)(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.59.4
+      eslint: 10.4.0
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.59.4(eslint@10.4.0)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.59.4
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/typescript-estree': 8.59.4(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.59.4
+      debug: 4.4.3
+      eslint: 10.4.0
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.59.4(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.59.4(typescript@6.0.3)
+      '@typescript-eslint/types': 8.59.4
+      debug: 4.4.3
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.59.4':
+    dependencies:
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/visitor-keys': 8.59.4
+
+  '@typescript-eslint/tsconfig-utils@8.59.4(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
+  '@typescript-eslint/type-utils@8.59.4(eslint@10.4.0)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/typescript-estree': 8.59.4(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.59.4(eslint@10.4.0)(typescript@6.0.3)
+      debug: 4.4.3
+      eslint: 10.4.0
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.59.4': {}
+
+  '@typescript-eslint/typescript-estree@8.59.4(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.59.4(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.4(typescript@6.0.3)
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/visitor-keys': 8.59.4
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.8.0
+      tinyglobby: 0.2.16
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.59.4(eslint@10.4.0)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0)
+      '@typescript-eslint/scope-manager': 8.59.4
+      '@typescript-eslint/types': 8.59.4
+      '@typescript-eslint/typescript-estree': 8.59.4(typescript@6.0.3)
+      eslint: 10.4.0
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.59.4':
+    dependencies:
+      '@typescript-eslint/types': 8.59.4
+      eslint-visitor-keys: 5.0.1
+
+  '@vitejs/plugin-vue@6.0.7(vite@8.0.13(@types/node@25.9.1))(vue@3.5.34(typescript@6.0.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.13
+      vite: 8.0.13(@types/node@25.9.1)
       vue: 3.5.34(typescript@6.0.3)
 
   '@vitest/expect@4.1.6':
@@ -925,13 +1504,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.6(vite@8.0.13)':
+  '@vitest/mocker@4.1.6(vite@8.0.13(@types/node@25.9.1))':
     dependencies:
       '@vitest/spy': 4.1.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.13
+      vite: 8.0.13(@types/node@25.9.1)
 
   '@vitest/pretty-format@4.1.6':
     dependencies:
@@ -1049,6 +1628,19 @@ snapshots:
 
   abbrev@2.0.0: {}
 
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
   alien-signals@3.2.1: {}
 
   ansi-regex@5.0.1: {}
@@ -1065,9 +1657,17 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
+  boolbase@1.0.0: {}
+
   brace-expansion@2.1.0:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
 
   chai@6.2.2: {}
 
@@ -1092,7 +1692,15 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  cssesc@3.0.0: {}
+
   csstype@3.2.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-is@0.1.4: {}
 
   detect-libc@2.1.2: {}
 
@@ -1115,17 +1723,133 @@ snapshots:
 
   es-module-lexer@2.1.0: {}
 
+  escape-string-regexp@4.0.0: {}
+
+  eslint-config-prettier@10.1.8(eslint@10.4.0):
+    dependencies:
+      eslint: 10.4.0
+
+  eslint-plugin-prettier@5.5.5(eslint-config-prettier@10.1.8(eslint@10.4.0))(eslint@10.4.0)(prettier@3.8.3):
+    dependencies:
+      eslint: 10.4.0
+      prettier: 3.8.3
+      prettier-linter-helpers: 1.0.1
+      synckit: 0.11.12
+    optionalDependencies:
+      eslint-config-prettier: 10.1.8(eslint@10.4.0)
+
+  eslint-plugin-vue@10.9.1(@typescript-eslint/parser@8.59.4(eslint@10.4.0)(typescript@6.0.3))(eslint@10.4.0)(vue-eslint-parser@10.4.0(eslint@10.4.0)):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0)
+      eslint: 10.4.0
+      natural-compare: 1.4.0
+      nth-check: 2.1.1
+      postcss-selector-parser: 7.1.1
+      semver: 7.8.0
+      vue-eslint-parser: 10.4.0(eslint@10.4.0)
+      xml-name-validator: 4.0.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.59.4(eslint@10.4.0)(typescript@6.0.3)
+
+  eslint-scope@9.1.2:
+    dependencies:
+      '@types/esrecurse': 4.3.1
+      '@types/estree': 1.0.9
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@10.4.0:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.23.5
+      '@eslint/config-helpers': 0.6.0
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.1
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      minimatch: 10.2.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@11.2.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 5.0.1
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
   estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
 
+  esutils@2.0.3: {}
+
   expect-type@1.3.0: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-diff@1.3.0: {}
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.2
+      keyv: 4.5.4
+
+  flatted@3.4.2: {}
 
   foreground-child@3.3.1:
     dependencies:
@@ -1134,6 +1858,10 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
 
   glob@10.5.0:
     dependencies:
@@ -1150,9 +1878,21 @@ snapshots:
       webidl-conversions: 7.0.0
       whatwg-mimetype: 3.0.0
 
+  ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
+
+  imurmurhash@0.1.4: {}
+
   ini@1.3.8: {}
 
+  is-extglob@2.1.1: {}
+
   is-fullwidth-code-point@3.0.0: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
 
   isexe@2.0.0: {}
 
@@ -1171,6 +1911,21 @@ snapshots:
       nopt: 7.2.1
 
   js-cookie@3.0.7: {}
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -1221,11 +1976,19 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
   lru-cache@10.4.3: {}
 
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
 
   minimatch@9.0.9:
     dependencies:
@@ -1233,19 +1996,46 @@ snapshots:
 
   minipass@7.1.3: {}
 
+  ms@2.1.3: {}
+
   muggle-string@0.4.1: {}
 
   nanoid@3.3.12: {}
+
+  natural-compare@1.4.0: {}
 
   nopt@7.2.1:
     dependencies:
       abbrev: 2.0.0
 
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
+
   obug@2.1.1: {}
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
 
   package-json-from-dist@1.0.1: {}
 
   path-browserify@1.0.1: {}
+
+  path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
 
@@ -1260,13 +2050,28 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  postcss-selector-parser@7.1.1:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
   postcss@8.5.14:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prelude-ls@1.2.1: {}
+
+  prettier-linter-helpers@1.0.1:
+    dependencies:
+      fast-diff: 1.3.0
+
+  prettier@3.8.3: {}
+
   proto-list@1.2.4: {}
+
+  punycode@2.3.1: {}
 
   rolldown@1.0.1:
     dependencies:
@@ -1327,6 +2132,10 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
+  synckit@0.11.12:
+    dependencies:
+      '@pkgr/core': 0.2.9
+
   tinybench@2.9.0: {}
 
   tinyexec@1.1.2: {}
@@ -1338,12 +2147,28 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  ts-api-utils@2.5.0(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
+
   tslib@2.8.1:
     optional: true
 
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
   typescript@6.0.3: {}
 
-  vite@8.0.13:
+  undici-types@7.24.6: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  util-deprecate@1.0.2: {}
+
+  vite@8.0.13(@types/node@25.9.1):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -1351,12 +2176,13 @@ snapshots:
       rolldown: 1.0.1
       tinyglobby: 0.2.16
     optionalDependencies:
+      '@types/node': 25.9.1
       fsevents: 2.3.3
 
-  vitest@4.1.6(happy-dom@15.11.7)(vite@8.0.13):
+  vitest@4.1.6(@types/node@25.9.1)(happy-dom@15.11.7)(vite@8.0.13(@types/node@25.9.1)):
     dependencies:
       '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(vite@8.0.13)
+      '@vitest/mocker': 4.1.6(vite@8.0.13(@types/node@25.9.1))
       '@vitest/pretty-format': 4.1.6
       '@vitest/runner': 4.1.6
       '@vitest/snapshot': 4.1.6
@@ -1373,9 +2199,10 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.13
+      vite: 8.0.13(@types/node@25.9.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@types/node': 25.9.1
       happy-dom: 15.11.7
     transitivePeerDependencies:
       - msw
@@ -1383,6 +2210,18 @@ snapshots:
   vscode-uri@3.1.0: {}
 
   vue-component-type-helpers@3.3.0: {}
+
+  vue-eslint-parser@10.4.0(eslint@10.4.0):
+    dependencies:
+      debug: 4.4.3
+      eslint: 10.4.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
+      semver: 7.8.0
+    transitivePeerDependencies:
+      - supports-color
 
   vue-tsc@3.3.0(typescript@6.0.3):
     dependencies:
@@ -1413,6 +2252,8 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  word-wrap@1.2.5: {}
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -1424,3 +2265,7 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 5.1.2
       strip-ansi: 7.2.0
+
+  xml-name-validator@4.0.0: {}
+
+  yocto-queue@0.1.0: {}

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 ignoredBuiltDependencies:
-  - esbuild
+    - esbuild
 minimumReleaseAgeExclude:
-  - '@vue/language-core@3.3.0'
-  - vue-tsc@3.3.0
+    - "@vue/language-core@3.3.0"
+    - vue-tsc@3.3.0

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -13,100 +13,114 @@ import LinkPasteModal from "./components/LinkPasteModal.vue"
 import JobToasts from "./components/JobToasts.vue"
 import { api } from "./api"
 import {
-  loadMaintenanceCount,
-  loadState,
-  loadWatchlistCount,
-  pushToast,
-  store,
+    loadMaintenanceCount,
+    loadState,
+    loadWatchlistCount,
+    pushToast,
+    store,
 } from "./store"
 
 const showPaste = ref(false)
 
 onMounted(() => {
-  loadState().catch(e => {
-    pushToast({ kind: "error", text: `Failed to load state: ${(e as Error).message}` })
-  })
-  loadMaintenanceCount()
-  loadWatchlistCount()
+    loadState().catch((e) => {
+        pushToast({
+            kind: "error",
+            text: `Failed to load state: ${(e as Error).message}`,
+        })
+    })
+    loadMaintenanceCount()
+    loadWatchlistCount()
 })
 
 const counts = computed(() => ({
-  library: store.titles.length,
-  synced: store.disk?.synced_titles ?? 0,
-  watchlist: store.watchlistCount ?? undefined,
-  // Maintenance is "attention required" not "inventory" — only badge when
-  // the count is positive. 0 means the user has nothing to do; no badge.
-  maintenance:
-    store.maintenanceCount != null && store.maintenanceCount > 0
-      ? store.maintenanceCount
-      : undefined,
+    library: store.titles.length,
+    synced: store.disk?.synced_titles ?? 0,
+    watchlist: store.watchlistCount ?? undefined,
+    // Maintenance is "attention required" not "inventory" — only badge when
+    // the count is positive. 0 means the user has nothing to do; no badge.
+    maintenance:
+        store.maintenanceCount != null && store.maintenanceCount > 0
+            ? store.maintenanceCount
+            : undefined,
 }))
 
 async function refresh(): Promise<void> {
-  try {
-    await api.refresh()
-    await loadState(true)
-    pushToast({ kind: "success", text: "Library rescanned." })
-  } catch (e) {
-    pushToast({ kind: "error", text: (e as Error).message })
-  }
+    try {
+        await api.refresh()
+        await loadState(true)
+        pushToast({ kind: "success", text: "Library rescanned." })
+    } catch (e) {
+        pushToast({ kind: "error", text: (e as Error).message })
+    }
 }
 
 // Global ⌘K / Ctrl-K → paste modal
 function onKeydown(e: KeyboardEvent): void {
-  if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
-    e.preventDefault()
-    showPaste.value = true
-  }
-  if (e.key === "Escape" && showPaste.value) {
-    showPaste.value = false
-  }
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault()
+        showPaste.value = true
+    }
+    if (e.key === "Escape" && showPaste.value) {
+        showPaste.value = false
+    }
 }
 window.addEventListener("keydown", onKeydown)
 </script>
 
 <template>
-  <div class="app">
-    <TopBar :on-paste-link="() => (showPaste = true)" :on-refresh="refresh" />
-    <TabBar :tab="store.tab" :counts="counts" @change="t => (store.tab = t)" />
+    <div class="app">
+        <TopBar
+            :on-paste-link="() => (showPaste = true)"
+            :on-refresh="refresh"
+        />
+        <TabBar
+            :tab="store.tab"
+            :counts="counts"
+            @change="(t) => (store.tab = t)"
+        />
 
-    <main class="main">
-      <!-- KeepAlive preserves Synced / Watchlist / Maintenance state across
+        <main class="main">
+            <!-- KeepAlive preserves Synced / Watchlist / Maintenance state across
            tab switches so leaving and returning is instant. Once loaded,
            these views stay mounted and re-show without re-fetching. Library
            is excluded because its TitleGrid is already store-backed and
            cheap to remount. -->
-      <template v-if="store.tab === 'library'">
-        <FilterBar />
-        <TitleGrid v-if="store.loaded" />
-        <div v-else class="loading">Loading library…</div>
-      </template>
-      <KeepAlive v-else>
-        <SyncedView      v-if="store.tab === 'synced'" />
-        <WatchlistView   v-else-if="store.tab === 'watchlist'" />
-        <MaintenanceView v-else-if="store.tab === 'maintenance'" />
-        <SyncthingView   v-else-if="store.tab === 'syncthing'" />
-      </KeepAlive>
-    </main>
+            <template v-if="store.tab === 'library'">
+                <FilterBar />
+                <TitleGrid v-if="store.loaded" />
+                <div v-else class="loading">Loading library…</div>
+            </template>
+            <KeepAlive v-else>
+                <SyncedView v-if="store.tab === 'synced'" />
+                <WatchlistView v-else-if="store.tab === 'watchlist'" />
+                <MaintenanceView v-else-if="store.tab === 'maintenance'" />
+                <SyncthingView v-else-if="store.tab === 'syncthing'" />
+            </KeepAlive>
+        </main>
 
-    <DetailDrawer v-if="store.detail" />
-    <LinkPasteModal v-if="showPaste" @close="showPaste = false" />
-    <JobToasts />
-  </div>
+        <DetailDrawer v-if="store.detail" />
+        <LinkPasteModal v-if="showPaste" @close="showPaste = false" />
+        <JobToasts />
+    </div>
 </template>
 
 <style scoped>
 .app {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  background: var(--bg);
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    background: var(--bg);
 }
 .main {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  min-height: 0;        /* allow children to scroll */
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0; /* allow children to scroll */
 }
-.loading { padding: 4rem 1rem; text-align: center; color: var(--fg-muted); }
+.loading {
+    padding: 4rem 1rem;
+    text-align: center;
+    color: var(--fg-muted);
+}
 </style>

--- a/frontend/src/DetailDrawer.test.ts
+++ b/frontend/src/DetailDrawer.test.ts
@@ -3,229 +3,249 @@ import { nextTick } from "vue"
 import { mount } from "@vue/test-utils"
 import DetailDrawer from "./components/DetailDrawer.vue"
 import { store } from "./store"
+import type { TitleDetail } from "./types"
 
 vi.mock("./api", () => ({
-  api: {
-    artUrl: () => "",
-    title: vi.fn(),
-    scrobble: vi.fn().mockResolvedValue({
-      scrobbled: 1,
-      failed: 0,
-      results: [{ season: 1, episode: 1, status: "ok" }],
-    }),
-    sync: vi.fn(),
-    unsync: vi.fn(),
-  },
+    api: {
+        artUrl: () => "",
+        title: vi.fn(),
+        scrobble: vi.fn().mockResolvedValue({
+            scrobbled: 1,
+            failed: 0,
+            results: [{ season: 1, episode: 1, status: "ok" }],
+        }),
+        sync: vi.fn(),
+        unsync: vi.fn(),
+    },
 }))
 
 const SHOW_FIXTURE = {
-  id: "tv/Test",
-  lib: "tv",
-  folder: "Test Show",
-  name: "Test Show",
-  kind: "show" as const,
-  year: 2024,
-  total_bytes: 0,
-  synced_bytes: 0,
-  files: [],
-  seasons: [
-    {
-      season: 1,
-      total_bytes: 0,
-      synced_episodes: 0,
-      watched_episodes: 0,
-      episodes: [
+    id: "tv/Test",
+    lib: "tv",
+    folder: "Test Show",
+    name: "Test Show",
+    kind: "show" as const,
+    year: 2024,
+    total_bytes: 0,
+    synced_bytes: 0,
+    files: [],
+    seasons: [
         {
-          season: 1, episode: 1, title: "Pilot", size_bytes: 0,
-          files: [], is_synced: false,
-          watch_state: "unwatched" as const, watch_pct: 0,
+            season: 1,
+            total_bytes: 0,
+            synced_episodes: 0,
+            watched_episodes: 0,
+            episodes: [
+                {
+                    season: 1,
+                    episode: 1,
+                    title: "Pilot",
+                    size_bytes: 0,
+                    files: [],
+                    is_synced: false,
+                    watch_state: "unwatched" as const,
+                    watch_pct: 0,
+                },
+                {
+                    season: 1,
+                    episode: 2,
+                    title: "Ep Two",
+                    size_bytes: 0,
+                    files: [],
+                    is_synced: false,
+                    watch_state: "unwatched" as const,
+                    watch_pct: 0,
+                },
+            ],
         },
-        {
-          season: 1, episode: 2, title: "Ep Two", size_bytes: 0,
-          files: [], is_synced: false,
-          watch_state: "unwatched" as const, watch_pct: 0,
-        },
-      ],
-    },
-  ],
+    ],
 }
 
 const MOVIE_FIXTURE = {
-  id: "movies/M",
-  lib: "movies",
-  folder: "M",
-  name: "Movie M",
-  kind: "movie" as const,
-  year: 2024,
-  total_bytes: 0,
-  synced_bytes: 0,
-  files: [],
-  seasons: [],
-  watched: false,
+    id: "movies/M",
+    lib: "movies",
+    folder: "M",
+    name: "Movie M",
+    kind: "movie" as const,
+    year: 2024,
+    total_bytes: 0,
+    synced_bytes: 0,
+    files: [],
+    seasons: [],
+    watched: false,
 }
 
 describe("DetailDrawer mark-watched affordances", () => {
-  it("renders Mark series watched + Mark season watched + per-episode mark buttons", async () => {
-    const { api } = await import("./api")
-    ;(api.title as ReturnType<typeof vi.fn>).mockResolvedValue(SHOW_FIXTURE)
-    store.detail = { lib: "tv", folder: "Test Show" }
+    it("renders Mark series watched + Mark season watched + per-episode mark buttons", async () => {
+        const { api } = await import("./api")
+        ;(api.title as ReturnType<typeof vi.fn>).mockResolvedValue(SHOW_FIXTURE)
+        store.detail = { lib: "tv", folder: "Test Show" }
 
-    const wrapper = mount(DetailDrawer)
-    // wait for onMounted + load + render
-    await new Promise(r => setTimeout(r, 50))
-    await nextTick()
-    await nextTick()
+        const wrapper = mount(DetailDrawer)
+        // wait for onMounted + load + render
+        await new Promise((r) => setTimeout(r, 50))
+        await nextTick()
+        await nextTick()
 
-    const html = wrapper.html()
-    expect(html).toContain('data-testid="mark-series-watched"')
-    expect(html).toContain('data-testid="mark-season-watched"')
-    expect(html).toContain('data-testid="mark-episode-watched"')
-    expect(html).toContain("Mark series watched")
-    // Two episode tiles, each with its own mark-watched button
-    expect(html.match(/data-testid="mark-episode-watched"/g)?.length).toBe(2)
+        const html = wrapper.html()
+        expect(html).toContain('data-testid="mark-series-watched"')
+        expect(html).toContain('data-testid="mark-season-watched"')
+        expect(html).toContain('data-testid="mark-episode-watched"')
+        expect(html).toContain("Mark series watched")
+        // Two episode tiles, each with its own mark-watched button
+        expect(html.match(/data-testid="mark-episode-watched"/g)?.length).toBe(
+            2
+        )
 
-    store.detail = null
-  })
-
-  it("renders Mark watched on the movie pane when movie is unwatched", async () => {
-    const { api } = await import("./api")
-    ;(api.title as ReturnType<typeof vi.fn>).mockResolvedValue(MOVIE_FIXTURE)
-    store.detail = { lib: "movies", folder: "M" }
-
-    const wrapper = mount(DetailDrawer)
-    await new Promise(r => setTimeout(r, 50))
-    await nextTick()
-    await nextTick()
-
-    const html = wrapper.html()
-    expect(html).toContain('data-testid="mark-movie-watched"')
-    expect(html).toContain("Mark watched")
-
-    store.detail = null
-  })
-
-  it("keeps season-level mark-watched sticky against a stale refresh (the Unsettled bug)", async () => {
-    // Simulates the exact bug Jake hit: scrobble lands at Plex, frontend
-    // optimistically updates, then refreshInPlace fires and api.title()
-    // returns stale watchstate data (the daemon hasn't caught up). Without
-    // the session overlay, the optimistic update gets clobbered.
-    const { api } = await import("./api")
-    const STALE_FIXTURE = JSON.parse(JSON.stringify(SHOW_FIXTURE))
-
-    // First call: initial load returns unwatched (real Plex state).
-    // Subsequent calls (refreshInPlace) also return unwatched (stale DB).
-    ;(api.title as ReturnType<typeof vi.fn>).mockResolvedValue(STALE_FIXTURE)
-    // Scrobble route returns ok for both episodes.
-    ;(api.scrobble as ReturnType<typeof vi.fn>).mockResolvedValue({
-      scrobbled: 2,
-      failed: 0,
-      results: [
-        { season: 1, episode: 1, status: "ok" },
-        { season: 1, episode: 2, status: "ok" },
-      ],
+        store.detail = null
     })
 
-    store.detail = { lib: "tv", folder: "Test Show" }
-    const wrapper = mount(DetailDrawer)
-    await new Promise(r => setTimeout(r, 50))
-    await nextTick()
+    it("renders Mark watched on the movie pane when movie is unwatched", async () => {
+        const { api } = await import("./api")
+        ;(api.title as ReturnType<typeof vi.fn>).mockResolvedValue(
+            MOVIE_FIXTURE
+        )
+        store.detail = { lib: "movies", folder: "M" }
 
-    // Trigger season-level mark-watched. The script setup exposes markWatched
-    // indirectly through the season button.
-    const seasonBtn = wrapper.find('[data-testid="mark-season-watched"]')
-    expect(seasonBtn.exists()).toBe(true)
+        const wrapper = mount(DetailDrawer)
+        await new Promise((r) => setTimeout(r, 50))
+        await nextTick()
+        await nextTick()
 
-    // Auto-confirm the window.confirm prompt (happy-dom may not define it).
-    window.confirm = () => true
-    await seasonBtn.trigger("click")
-    // Let the scrobble Promise + optimistic update flush.
-    await nextTick()
-    await new Promise(r => setTimeout(r, 50))
-    await nextTick()
+        const html = wrapper.html()
+        expect(html).toContain('data-testid="mark-movie-watched"')
+        expect(html).toContain("Mark watched")
 
-    // Trigger the refresh that previously clobbered the UI. The 1s timer
-    // fires inside markWatched; vi can't easily fast-forward the real
-    // setTimeout here without setting up fake timers, so we just call the
-    // refresh-equivalent: another mock api.title returns stale data,
-    // applyScrobbleOverlay should re-apply watched to the scrobbled episodes.
-    // We assert by reading the rendered DOM: the watched indicator (.ico.watched
-    // ●) should be present for both episodes.
-
-    // Wait a beat for the 1s refresh timer to fire.
-    await new Promise(r => setTimeout(r, 1200))
-    await nextTick()
-    await nextTick()
-
-    const html = wrapper.html()
-    // Both episodes should show the watched indicator (● in EpisodeTile) — the
-    // session overlay re-applied on the stale refresh.
-    const watchedDots = (html.match(/class="ico watched"/g) ?? []).length
-    expect(watchedDots).toBe(2)
-
-    store.detail = null
-  })
-
-  it("overlay survives drawer re-mount within the same session", async () => {
-    // User marks an episode watched, closes the drawer (navigates away),
-    // reopens it. WatchState still hasn't synced, so api.title returns the
-    // same stale unwatched state. The overlay must still re-apply.
-    const { api } = await import("./api")
-    const STALE = JSON.parse(JSON.stringify(SHOW_FIXTURE))
-    ;(api.title as ReturnType<typeof vi.fn>).mockResolvedValue(STALE)
-    ;(api.scrobble as ReturnType<typeof vi.fn>).mockResolvedValue({
-      scrobbled: 2, failed: 0,
-      results: [
-        { season: 1, episode: 1, status: "ok" },
-        { season: 1, episode: 2, status: "ok" },
-      ],
+        store.detail = null
     })
-    window.confirm = () => true
 
-    // First mount: open drawer, scrobble episode 1.
-    store.detail = { lib: "tv", folder: "Test Show" }
-    const w1 = mount(DetailDrawer)
-    await new Promise(r => setTimeout(r, 50))
-    await nextTick()
-    // Use the season-level button (always rendered when the season header is
-     // visible, no hover dependency).
-    const seasonBtn = w1.find('[data-testid="mark-season-watched"]')
-    expect(seasonBtn.exists()).toBe(true)
-    await seasonBtn.trigger("click")
-    await nextTick()
-    await new Promise(r => setTimeout(r, 50))
-    w1.unmount()
-    store.detail = null
+    it("keeps season-level mark-watched sticky against a stale refresh (the Unsettled bug)", async () => {
+        // Simulates the exact bug Jake hit: scrobble lands at Plex, frontend
+        // optimistically updates, then refreshInPlace fires and api.title()
+        // returns stale watchstate data (the daemon hasn't caught up). Without
+        // the session overlay, the optimistic update gets clobbered.
+        const { api } = await import("./api")
+        const STALE_FIXTURE = JSON.parse(
+            JSON.stringify(SHOW_FIXTURE)
+        ) as TitleDetail
 
-    // Second mount: same lib/folder, api still returns stale.
-    store.detail = { lib: "tv", folder: "Test Show" }
-    const w2 = mount(DetailDrawer)
-    await new Promise(r => setTimeout(r, 50))
-    await nextTick()
+        // First call: initial load returns unwatched (real Plex state).
+        // Subsequent calls (refreshInPlace) also return unwatched (stale DB).
+        ;(api.title as ReturnType<typeof vi.fn>).mockResolvedValue(
+            STALE_FIXTURE
+        )
+        // Scrobble route returns ok for both episodes.
+        ;(api.scrobble as ReturnType<typeof vi.fn>).mockResolvedValue({
+            scrobbled: 2,
+            failed: 0,
+            results: [
+                { season: 1, episode: 1, status: "ok" },
+                { season: 1, episode: 2, status: "ok" },
+            ],
+        })
 
-    // The previously-scrobbled episode must still show as watched even
-    // though the API call returned unwatched.
-    const html = w2.html()
-    expect(html).toMatch(/class="ico watched"/)
+        store.detail = { lib: "tv", folder: "Test Show" }
+        const wrapper = mount(DetailDrawer)
+        await new Promise((r) => setTimeout(r, 50))
+        await nextTick()
 
-    store.detail = null
-  })
+        // Trigger season-level mark-watched. The script setup exposes markWatched
+        // indirectly through the season button.
+        const seasonBtn = wrapper.find('[data-testid="mark-season-watched"]')
+        expect(seasonBtn.exists()).toBe(true)
 
-  it("does NOT render Mark watched on a movie pane when watched is true", async () => {
-    const { api } = await import("./api")
-    ;(api.title as ReturnType<typeof vi.fn>).mockResolvedValue({
-      ...MOVIE_FIXTURE,
-      watched: true,
+        // Auto-confirm the window.confirm prompt (happy-dom may not define it).
+        window.confirm = () => true
+        await seasonBtn.trigger("click")
+        // Let the scrobble Promise + optimistic update flush.
+        await nextTick()
+        await new Promise((r) => setTimeout(r, 50))
+        await nextTick()
+
+        // Trigger the refresh that previously clobbered the UI. The 1s timer
+        // fires inside markWatched; vi can't easily fast-forward the real
+        // setTimeout here without setting up fake timers, so we just call the
+        // refresh-equivalent: another mock api.title returns stale data,
+        // applyScrobbleOverlay should re-apply watched to the scrobbled episodes.
+        // We assert by reading the rendered DOM: the watched indicator (.ico.watched
+        // ●) should be present for both episodes.
+
+        // Wait a beat for the 1s refresh timer to fire.
+        await new Promise((r) => setTimeout(r, 1200))
+        await nextTick()
+        await nextTick()
+
+        const html = wrapper.html()
+        // Both episodes should show the watched indicator (● in EpisodeTile) — the
+        // session overlay re-applied on the stale refresh.
+        const watchedDots = (html.match(/class="ico watched"/g) ?? []).length
+        expect(watchedDots).toBe(2)
+
+        store.detail = null
     })
-    store.detail = { lib: "movies", folder: "M" }
 
-    const wrapper = mount(DetailDrawer)
-    await new Promise(r => setTimeout(r, 50))
-    await nextTick()
-    await nextTick()
+    it("overlay survives drawer re-mount within the same session", async () => {
+        // User marks an episode watched, closes the drawer (navigates away),
+        // reopens it. WatchState still hasn't synced, so api.title returns the
+        // same stale unwatched state. The overlay must still re-apply.
+        const { api } = await import("./api")
+        const STALE = JSON.parse(JSON.stringify(SHOW_FIXTURE)) as TitleDetail
+        ;(api.title as ReturnType<typeof vi.fn>).mockResolvedValue(STALE)
+        ;(api.scrobble as ReturnType<typeof vi.fn>).mockResolvedValue({
+            scrobbled: 2,
+            failed: 0,
+            results: [
+                { season: 1, episode: 1, status: "ok" },
+                { season: 1, episode: 2, status: "ok" },
+            ],
+        })
+        window.confirm = () => true
 
-    const html = wrapper.html()
-    expect(html).not.toContain('data-testid="mark-movie-watched"')
+        // First mount: open drawer, scrobble episode 1.
+        store.detail = { lib: "tv", folder: "Test Show" }
+        const w1 = mount(DetailDrawer)
+        await new Promise((r) => setTimeout(r, 50))
+        await nextTick()
+        // Use the season-level button (always rendered when the season header is
+        // visible, no hover dependency).
+        const seasonBtn = w1.find('[data-testid="mark-season-watched"]')
+        expect(seasonBtn.exists()).toBe(true)
+        await seasonBtn.trigger("click")
+        await nextTick()
+        await new Promise((r) => setTimeout(r, 50))
+        w1.unmount()
+        store.detail = null
 
-    store.detail = null
-  })
+        // Second mount: same lib/folder, api still returns stale.
+        store.detail = { lib: "tv", folder: "Test Show" }
+        const w2 = mount(DetailDrawer)
+        await new Promise((r) => setTimeout(r, 50))
+        await nextTick()
+
+        // The previously-scrobbled episode must still show as watched even
+        // though the API call returned unwatched.
+        const html = w2.html()
+        expect(html).toMatch(/class="ico watched"/)
+
+        store.detail = null
+    })
+
+    it("does NOT render Mark watched on a movie pane when watched is true", async () => {
+        const { api } = await import("./api")
+        ;(api.title as ReturnType<typeof vi.fn>).mockResolvedValue({
+            ...MOVIE_FIXTURE,
+            watched: true,
+        })
+        store.detail = { lib: "movies", folder: "M" }
+
+        const wrapper = mount(DetailDrawer)
+        await new Promise((r) => setTimeout(r, 50))
+        await nextTick()
+        await nextTick()
+
+        const html = wrapper.html()
+        expect(html).not.toContain('data-testid="mark-movie-watched"')
+
+        store.detail = null
+    })
 })

--- a/frontend/src/EpisodeTile.test.ts
+++ b/frontend/src/EpisodeTile.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest"
+import { mount } from "@vue/test-utils"
+import EpisodeTile from "./components/EpisodeTile.vue"
+import type { Episode } from "./types"
+
+// onKey was refactored to drop unused season/episode params (the click event
+// already carries them via $emit). Pin the keyboard a11y contract so the
+// keydown -> click bridge can't regress: Enter/Space must synthesize a click,
+// and the click must emit `toggle` with the right season/episode.
+
+function makeEpisode(overrides: Partial<Episode> = {}): Episode {
+    return {
+        season: 2,
+        episode: 5,
+        title: "The One With The Test",
+        size_bytes: 0,
+        files: [],
+        is_synced: false,
+        watch_state: "unwatched",
+        watch_pct: 0,
+        ...overrides,
+    }
+}
+
+describe("EpisodeTile keyboard activation", () => {
+    it("emits toggle on Enter keydown with the tile's season/episode", async () => {
+        const ep = makeEpisode()
+        const wrapper = mount(EpisodeTile, {
+            props: { ep, selected: false },
+        })
+
+        await wrapper
+            .find('[role="button"]')
+            .trigger("keydown", { key: "Enter" })
+
+        const emitted = wrapper.emitted("toggle")
+        expect(emitted).toBeTruthy()
+        expect(emitted![0]).toEqual([2, 5, false])
+    })
+
+    it("emits toggle on Space keydown", async () => {
+        const ep = makeEpisode({ season: 3, episode: 7 })
+        const wrapper = mount(EpisodeTile, {
+            props: { ep, selected: false },
+        })
+
+        await wrapper.find('[role="button"]').trigger("keydown", { key: " " })
+
+        const emitted = wrapper.emitted("toggle")
+        expect(emitted).toBeTruthy()
+        expect(emitted![0]).toEqual([3, 7, false])
+    })
+
+    it("propagates shift modifier when shift is held during Enter", async () => {
+        const ep = makeEpisode()
+        const wrapper = mount(EpisodeTile, {
+            props: { ep, selected: false },
+        })
+
+        await wrapper
+            .find('[role="button"]')
+            .trigger("keydown", { key: "Enter", shiftKey: true })
+
+        const emitted = wrapper.emitted("toggle")
+        expect(emitted).toBeTruthy()
+        expect(emitted![0]).toEqual([2, 5, true])
+    })
+
+    it("ignores non-activation keys", async () => {
+        const ep = makeEpisode()
+        const wrapper = mount(EpisodeTile, {
+            props: { ep, selected: false },
+        })
+
+        await wrapper.find('[role="button"]').trigger("keydown", { key: "a" })
+        await wrapper.find('[role="button"]').trigger("keydown", { key: "Tab" })
+        await wrapper
+            .find('[role="button"]')
+            .trigger("keydown", { key: "ArrowRight" })
+
+        expect(wrapper.emitted("toggle")).toBeUndefined()
+    })
+
+    it("calls preventDefault on Space so the page doesn't scroll", async () => {
+        const ep = makeEpisode()
+        const wrapper = mount(EpisodeTile, {
+            props: { ep, selected: false },
+        })
+
+        const preventDefault = vi.fn()
+        await wrapper
+            .find('[role="button"]')
+            .trigger("keydown", { key: " ", preventDefault })
+
+        expect(preventDefault).toHaveBeenCalled()
+    })
+})

--- a/frontend/src/JobToasts.test.ts
+++ b/frontend/src/JobToasts.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, beforeEach } from "vitest"
+import { mount } from "@vue/test-utils"
+import { nextTick } from "vue"
+import JobToasts from "./components/JobToasts.vue"
+import { store } from "./store"
+import type { Job } from "./types"
+
+// JobToasts' progress bar branches on (a) toast.jobId being present, (b) the
+// referenced job existing in store.jobs, and (c) job.status === "running". The
+// runningJob/jobWidth helpers collapse those three conditions; these tests
+// pin the visible behavior for each branch so the helpers can't drift silently.
+
+function makeJob(overrides: Partial<Job> = {}): Job {
+    return {
+        id: "job-1",
+        op: "sync",
+        status: "running",
+        total_files: 10,
+        total_media_files: 8,
+        processed_files: 5,
+        processed_media_files: 4,
+        processed_bytes: 500,
+        total_bytes: 1000,
+        current_file: "movie.mkv",
+        title: "Test",
+        started_at: 0,
+        ended_at: 0,
+        error: "",
+        ...overrides,
+    }
+}
+
+describe("JobToasts progress bar", () => {
+    beforeEach(() => {
+        // Reset the reactive store between tests so toasts/jobs don't bleed.
+        store.toasts = []
+        store.jobs = {}
+    })
+
+    it("renders the progress bar with width % for a running tracked job", async () => {
+        store.jobs["job-1"] = makeJob()
+        store.toasts.push({
+            id: "t1",
+            kind: "info",
+            text: "Syncing…",
+            jobId: "job-1",
+        })
+
+        const wrapper = mount(JobToasts)
+        await nextTick()
+
+        const bar = wrapper.find(".progress .bar")
+        expect(bar.exists()).toBe(true)
+        // 500 / 1000 = 50%
+        expect(bar.attributes("style")).toContain("width: 50%")
+    })
+
+    it("does not render the progress bar for a done job", async () => {
+        store.jobs["job-2"] = makeJob({ id: "job-2", status: "done" })
+        store.toasts.push({
+            id: "t2",
+            kind: "success",
+            text: "Done",
+            jobId: "job-2",
+        })
+
+        const wrapper = mount(JobToasts)
+        await nextTick()
+
+        expect(wrapper.find(".progress").exists()).toBe(false)
+    })
+
+    it("does not render the progress bar for a toast with no jobId", async () => {
+        store.toasts.push({
+            id: "t3",
+            kind: "error",
+            text: "Bad day",
+        })
+
+        const wrapper = mount(JobToasts)
+        await nextTick()
+
+        expect(wrapper.find(".progress").exists()).toBe(false)
+    })
+
+    it("does not render the progress bar when the job is missing from the store", async () => {
+        // toast points at a job that was never registered (e.g., the job
+        // record got pruned but the toast is still alive).
+        store.toasts.push({
+            id: "t4",
+            kind: "info",
+            text: "Stale",
+            jobId: "ghost-job",
+        })
+
+        const wrapper = mount(JobToasts)
+        await nextTick()
+
+        expect(wrapper.find(".progress").exists()).toBe(false)
+    })
+
+    it("clamps the width to 100% when processed > total", async () => {
+        // Defensive against a backend that briefly reports processed > total
+        // (rounding, post-completion job update). Should not produce width:120%.
+        store.jobs["job-3"] = makeJob({
+            id: "job-3",
+            processed_bytes: 1200,
+            total_bytes: 1000,
+        })
+        store.toasts.push({
+            id: "t5",
+            kind: "info",
+            text: "Syncing…",
+            jobId: "job-3",
+        })
+
+        const wrapper = mount(JobToasts)
+        await nextTick()
+
+        const bar = wrapper.find(".progress .bar")
+        expect(bar.attributes("style")).toContain("width: 100%")
+    })
+
+    it("renders width 0% when total_bytes is zero (avoids NaN)", async () => {
+        store.jobs["job-4"] = makeJob({
+            id: "job-4",
+            processed_bytes: 0,
+            total_bytes: 0,
+        })
+        store.toasts.push({
+            id: "t6",
+            kind: "info",
+            text: "Syncing…",
+            jobId: "job-4",
+        })
+
+        const wrapper = mount(JobToasts)
+        await nextTick()
+
+        const bar = wrapper.find(".progress .bar")
+        expect(bar.attributes("style")).toContain("width: 0%")
+    })
+})

--- a/frontend/src/MaintenanceView.test.ts
+++ b/frontend/src/MaintenanceView.test.ts
@@ -1,77 +1,197 @@
-import { describe, expect, it, vi, beforeAll } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import { nextTick } from "vue"
 import { mount } from "@vue/test-utils"
 import MaintenanceView from "./components/MaintenanceView.vue"
 
-// Stub the api module so we control the wire data.
-vi.mock("./api", () => ({
-  api: {
-    maintWatched: () => Promise.resolve({ items: [] }),
-    maintHanging: () => Promise.resolve({ items: [] }),
-    maintIgnored: () => Promise.resolve({
-      version: 1,
-      pending: [],
-      watched: [],
-      hanging: [],
-    }),
-    maintIgnore: vi.fn().mockResolvedValue({ ok: true }),
-    maintUnignore: vi.fn().mockResolvedValue({ ok: true }),
-    maintPending: () => Promise.resolve({
-      items: [
-        {
-          sync_sub: "movies",
-          folder: "Synclet Ship Test Movie (2099) {tmdb-0}",
-          title: "Synclet Ship Test Movie (2099)",
-          kind: "movie",
-          lib: null,
-          rating_key: null,
-          already_watched_in_plex: false,
-        },
-        {
-          sync_sub: "tv",
-          folder: "Synclet Ship Test Show (2099) {tvdb-0}",
-          title: "Synclet Ship Test Show (2099)",
-          kind: "show",
-          lib: null,
-          rating_key: null,
-          seasons: [
-            {
-              season: 1,
-              episodes: [
-                { season: 1, episode: 1, already_watched_in_plex: true, episode_rating_key: null, title: "" },
-                { season: 1, episode: 2, already_watched_in_plex: false, episode_rating_key: null, title: "" },
-              ],
-            },
-          ],
-        },
-      ],
-    }),
-    maintResolve: vi.fn().mockResolvedValue({
-      results: [],
-      cleanup: { removed_files: 0, removed_dirs: 0 },
-    }),
-  },
+// Each describe gets a fresh mock module so we can inspect the wire shape the
+// component sends to api.maintIgnore. Hoisted so vi.mock() can see it.
+const { maintIgnoreMock, maintUnignoreMock } = vi.hoisted(() => ({
+    maintIgnoreMock: vi.fn().mockResolvedValue({ ok: true }),
+    maintUnignoreMock: vi.fn().mockResolvedValue({ ok: true }),
 }))
 
-describe("MaintenanceView pending pane visual artifact", () => {
-  it("renders the new pending-deletions pane with movie and show groups", async () => {
+vi.mock("./api", () => ({
+    api: {
+        maintWatched: () =>
+            Promise.resolve({
+                items: [
+                    {
+                        title: "Old Movie",
+                        lib: "movies",
+                        folder: "Old Movie (1999)",
+                        files: ["/data/Old Movie (1999)/movie.mkv"],
+                        size_bytes: 100,
+                        file_count: 1,
+                    },
+                ],
+            }),
+        maintHanging: () =>
+            Promise.resolve({
+                items: [
+                    {
+                        path: "/data/orphan.mkv",
+                        rel: "orphan.mkv",
+                        size_bytes: 50,
+                    },
+                ],
+            }),
+        maintIgnored: () =>
+            Promise.resolve({
+                version: 1,
+                pending: [],
+                watched: [],
+                hanging: [],
+            }),
+        maintIgnore: maintIgnoreMock,
+        maintUnignore: maintUnignoreMock,
+        maintPending: () =>
+            Promise.resolve({
+                items: [
+                    {
+                        sync_sub: "movies",
+                        folder: "Synclet Ship Test Movie (2099) {tmdb-0}",
+                        title: "Synclet Ship Test Movie (2099)",
+                        kind: "movie",
+                        lib: null,
+                        rating_key: null,
+                        already_watched_in_plex: false,
+                    },
+                    {
+                        sync_sub: "tv",
+                        folder: "Synclet Ship Test Show (2099) {tvdb-0}",
+                        title: "Synclet Ship Test Show (2099)",
+                        kind: "show",
+                        lib: null,
+                        rating_key: null,
+                        seasons: [
+                            {
+                                season: 1,
+                                episodes: [
+                                    {
+                                        season: 1,
+                                        episode: 1,
+                                        already_watched_in_plex: true,
+                                        episode_rating_key: null,
+                                        title: "",
+                                    },
+                                    {
+                                        season: 1,
+                                        episode: 2,
+                                        already_watched_in_plex: false,
+                                        episode_rating_key: null,
+                                        title: "",
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            }),
+        maintResolve: vi.fn().mockResolvedValue({
+            results: [],
+            cleanup: { removed_files: 0, removed_dirs: 0 },
+        }),
+    },
+}))
+
+async function mountWaited(): Promise<ReturnType<typeof mount>> {
     const wrapper = mount(MaintenanceView)
-    // Wait for onMounted + Promise resolution + reactivity flush
-    await new Promise(r => setTimeout(r, 50))
+    await new Promise((r) => setTimeout(r, 50))
     await nextTick()
     await nextTick()
+    return wrapper
+}
 
-    const html = wrapper.html()
+describe("MaintenanceView pending pane visual artifact", () => {
+    it("renders the new pending-deletions pane with movie and show groups", async () => {
+        const wrapper = await mountWaited()
+        const html = wrapper.html()
 
-    expect(html).toContain("Deleted, awaiting Plex sync")
-    expect(html).toContain("Synclet Ship Test Movie")
-    expect(html).toContain("Synclet Ship Test Show")
-    expect(html).toContain("Mark all watched")
-    expect(html).toContain("Reject all")
-    expect(html).toContain("Mark watched")
-    expect(html).toContain("Reject")
-    expect(html).toContain('data-testid="pending-deletions"')
-    // Ignore affordance present on the movie row.
-    expect(html).toContain("Ignore")
-  })
+        expect(html).toContain("Deleted, awaiting Plex sync")
+        expect(html).toContain("Synclet Ship Test Movie")
+        expect(html).toContain("Synclet Ship Test Show")
+        expect(html).toContain("Mark all watched")
+        expect(html).toContain("Reject all")
+        expect(html).toContain("Mark watched")
+        expect(html).toContain("Reject")
+        expect(html).toContain('data-testid="pending-deletions"')
+        // Ignore affordance present on the movie row.
+        expect(html).toContain("Ignore")
+    })
+})
+
+// Each test calls a single Ignore button and asserts the wire body shape the
+// frontend sent. The backend route branches on `kind`, so getting the union
+// shape wrong here is the kind of bug that ships silently — no rendering
+// difference, just a 422 at click time. These contract tests pin the shape.
+describe("MaintenanceView ignore-button wire contract", () => {
+    it("sends a watched-kind IgnoreOp when clicking Ignore on a watched row", async () => {
+        maintIgnoreMock.mockClear()
+        const wrapper = await mountWaited()
+
+        // Find the watched-pane Ignore button. Watched panel comes first, so
+        // the first button labeled "Ignore" inside it is the watched one.
+        const watchedSection = wrapper
+            .findAll("section")
+            .find((s) => s.html().includes("Watched in synced-media"))
+        expect(watchedSection).toBeDefined()
+        const ignoreBtn = watchedSection!
+            .findAll("button")
+            .find((b) => b.text() === "Ignore")
+        expect(ignoreBtn).toBeDefined()
+        await ignoreBtn!.trigger("click")
+
+        expect(maintIgnoreMock).toHaveBeenCalledTimes(1)
+        expect(maintIgnoreMock).toHaveBeenCalledWith({
+            kind: "watched",
+            ref: { lib: "movies", folder: "Old Movie (1999)" },
+        })
+    })
+
+    it("sends a hanging-kind IgnoreOp when clicking Ignore on a hanging row", async () => {
+        maintIgnoreMock.mockClear()
+        const wrapper = await mountWaited()
+
+        const hangingSection = wrapper
+            .findAll("section")
+            .find((s) => s.html().includes("Hanging files"))
+        expect(hangingSection).toBeDefined()
+        const ignoreBtn = hangingSection!
+            .findAll("button")
+            .find((b) => b.text() === "Ignore")
+        expect(ignoreBtn).toBeDefined()
+        await ignoreBtn!.trigger("click")
+
+        expect(maintIgnoreMock).toHaveBeenCalledTimes(1)
+        expect(maintIgnoreMock).toHaveBeenCalledWith({
+            kind: "hanging",
+            ref: { path: "/data/orphan.mkv" },
+        })
+    })
+
+    it("sends a pending-kind IgnoreOp with null season/episode for a movie row", async () => {
+        maintIgnoreMock.mockClear()
+        const wrapper = await mountWaited()
+
+        const pendingSection = wrapper.find('[data-testid="pending-deletions"]')
+        expect(pendingSection.exists()).toBe(true)
+        // Movie row Ignore button (the show row uses a Mark-all/Reject-all
+        // header without an Ignore at that level).
+        const ignoreBtn = pendingSection
+            .findAll("button")
+            .find((b) => b.text() === "Ignore")
+        expect(ignoreBtn).toBeDefined()
+        await ignoreBtn!.trigger("click")
+
+        expect(maintIgnoreMock).toHaveBeenCalledTimes(1)
+        expect(maintIgnoreMock).toHaveBeenCalledWith({
+            kind: "pending",
+            ref: {
+                sync_sub: "movies",
+                folder: "Synclet Ship Test Movie (2099) {tmdb-0}",
+                season: null,
+                episode: null,
+            },
+        })
+    })
 })

--- a/frontend/src/SyncthingView.test.ts
+++ b/frontend/src/SyncthingView.test.ts
@@ -1,153 +1,158 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { flushPromises, mount } from "@vue/test-utils"
 import SyncthingView from "./components/SyncthingView.vue"
+import type { SyncthingFolder, SyncthingOverview } from "./types"
 
 // Stub the api module so each test controls the wire data and we can
 // count poll cycles.
-const mockOverview = vi.fn()
+const mockOverview = vi.fn<() => Promise<SyncthingOverview>>()
 vi.mock("./api", () => ({
-  api: {
-    syncthingOverview: () => mockOverview(),
-  },
+    api: {
+        syncthingOverview: (): Promise<SyncthingOverview> => mockOverview(),
+    },
 }))
 
-const HAPPY_OVERVIEW = {
-  configured: true,
-  folders: [
-    {
-      folder_id: "default",
-      label: "Media",
-      percent: 75,
-      state: "syncing",
-      need_bytes: 250,
-      in_sync_bytes: 750,
-      global_bytes: 1000,
-      devices: [
+// Named so test variants can spread it without an indexed lookup (which is
+// `T | undefined` under noUncheckedIndexedAccess).
+const HAPPY_FOLDER: SyncthingFolder = {
+    folder_id: "default",
+    label: "Media",
+    percent: 75,
+    state: "syncing",
+    need_bytes: 250,
+    in_sync_bytes: 750,
+    global_bytes: 1000,
+    devices: [
         {
-          device_id: "DEV_LAPTOP",
-          name: "Laptop",
-          completion: 100,
-          need_bytes: 0,
-          connected: true,
-          paused: false,
+            device_id: "DEV_LAPTOP",
+            name: "Laptop",
+            completion: 100,
+            need_bytes: 0,
+            connected: true,
+            paused: false,
         },
         {
-          device_id: "DEV_PHONE",
-          name: "Phone",
-          completion: 60,
-          need_bytes: 400,
-          connected: false,
-          paused: false,
+            device_id: "DEV_PHONE",
+            name: "Phone",
+            completion: 60,
+            need_bytes: 400,
+            connected: false,
+            paused: false,
         },
-      ],
-    },
-  ],
+    ],
+}
+
+const HAPPY_OVERVIEW: SyncthingOverview = {
+    configured: true,
+    folders: [HAPPY_FOLDER],
 }
 
 describe("SyncthingView", () => {
-  beforeEach(() => {
-    mockOverview.mockReset()
-  })
-
-  afterEach(() => {
-    // Belt-and-suspenders: tests that opted into fake timers must restore
-    // real ones before the next test runs, even if they threw mid-flight.
-    vi.useRealTimers()
-  })
-
-  describe("render states", () => {
-    it("shows the not-configured panel when backend reports configured=false", async () => {
-      mockOverview.mockResolvedValue({ configured: false, folders: [] })
-      const wrapper = mount(SyncthingView)
-      await flushPromises()
-      expect(wrapper.text()).toContain("Syncthing not configured")
-      expect(wrapper.text()).toContain("SYNCTHING_URL")
-      expect(wrapper.text()).toContain("SYNCTHING_API_KEY")
+    beforeEach(() => {
+        mockOverview.mockReset()
     })
 
-    it("renders folder rows + per-device chips when populated", async () => {
-      mockOverview.mockResolvedValue(HAPPY_OVERVIEW)
-      const wrapper = mount(SyncthingView)
-      await flushPromises()
-
-      const text = wrapper.text()
-      expect(text).toContain("Media")
-      expect(text).toContain("75%")
-      expect(text).toContain("syncing")
-
-      // Both devices visible with their completion and state tags.
-      expect(text).toContain("Laptop")
-      expect(text).toContain("100%")
-      expect(text).toContain("in sync")
-      expect(text).toContain("Phone")
-      expect(text).toContain("60%")
-      expect(text).toContain("offline")
+    afterEach(() => {
+        // Belt-and-suspenders: tests that opted into fake timers must restore
+        // real ones before the next test runs, even if they threw mid-flight.
+        vi.useRealTimers()
     })
 
-    it("shows the empty-folders message when configured but Syncthing has no folders", async () => {
-      mockOverview.mockResolvedValue({ configured: true, folders: [] })
-      const wrapper = mount(SyncthingView)
-      await flushPromises()
-      expect(wrapper.text()).toContain("no folders are configured")
+    describe("render states", () => {
+        it("shows the not-configured panel when backend reports configured=false", async () => {
+            mockOverview.mockResolvedValue({ configured: false, folders: [] })
+            const wrapper = mount(SyncthingView)
+            await flushPromises()
+            expect(wrapper.text()).toContain("Syncthing not configured")
+            expect(wrapper.text()).toContain("SYNCTHING_URL")
+            expect(wrapper.text()).toContain("SYNCTHING_API_KEY")
+        })
+
+        it("renders folder rows + per-device chips when populated", async () => {
+            mockOverview.mockResolvedValue(HAPPY_OVERVIEW)
+            const wrapper = mount(SyncthingView)
+            await flushPromises()
+
+            const text = wrapper.text()
+            expect(text).toContain("Media")
+            expect(text).toContain("75%")
+            expect(text).toContain("syncing")
+
+            // Both devices visible with their completion and state tags.
+            expect(text).toContain("Laptop")
+            expect(text).toContain("100%")
+            expect(text).toContain("in sync")
+            expect(text).toContain("Phone")
+            expect(text).toContain("60%")
+            expect(text).toContain("offline")
+        })
+
+        it("shows the empty-folders message when configured but Syncthing has no folders", async () => {
+            mockOverview.mockResolvedValue({ configured: true, folders: [] })
+            const wrapper = mount(SyncthingView)
+            await flushPromises()
+            expect(wrapper.text()).toContain("no folders are configured")
+        })
+
+        it("shows the no-remote-devices message for a folder without sharers", async () => {
+            mockOverview.mockResolvedValue({
+                configured: true,
+                folders: [
+                    {
+                        ...HAPPY_FOLDER,
+                        devices: [],
+                    },
+                ],
+            })
+            const wrapper = mount(SyncthingView)
+            await flushPromises()
+            expect(wrapper.text()).toContain(
+                "No remote devices share this folder"
+            )
+        })
     })
 
-    it("shows the no-remote-devices message for a folder without sharers", async () => {
-      mockOverview.mockResolvedValue({
-        configured: true,
-        folders: [
-          {
-            ...HAPPY_OVERVIEW.folders[0],
-            devices: [],
-          },
-        ],
-      })
-      const wrapper = mount(SyncthingView)
-      await flushPromises()
-      expect(wrapper.text()).toContain("No remote devices share this folder")
+    describe("polling cadence", () => {
+        it("polls the overview endpoint every 8s while mounted", async () => {
+            mockOverview.mockResolvedValue(HAPPY_OVERVIEW)
+            vi.useFakeTimers()
+
+            const wrapper = mount(SyncthingView)
+            // Initial load fires synchronously from onMounted (returns a Promise
+            // we need to flush). Do NOT use vi.runOnlyPendingTimersAsync here:
+            // it fires the setInterval's first tick prematurely.
+            await flushPromises()
+            expect(mockOverview).toHaveBeenCalledTimes(1)
+
+            // Just under 8s: no new call yet.
+            await vi.advanceTimersByTimeAsync(7000)
+            expect(mockOverview).toHaveBeenCalledTimes(1)
+
+            // Crossing the 8s boundary fires the next poll.
+            await vi.advanceTimersByTimeAsync(1500)
+            expect(mockOverview).toHaveBeenCalledTimes(2)
+
+            // Another full 8s cycle.
+            await vi.advanceTimersByTimeAsync(8000)
+            expect(mockOverview).toHaveBeenCalledTimes(3)
+
+            wrapper.unmount()
+        })
+
+        it("stops polling after unmount", async () => {
+            mockOverview.mockResolvedValue(HAPPY_OVERVIEW)
+            vi.useFakeTimers()
+
+            const wrapper = mount(SyncthingView)
+            await flushPromises()
+            expect(mockOverview).toHaveBeenCalledTimes(1)
+
+            wrapper.unmount()
+
+            // After unmount, no further polls should land regardless of how
+            // much time passes.
+            await vi.advanceTimersByTimeAsync(30_000)
+            expect(mockOverview).toHaveBeenCalledTimes(1)
+        })
     })
-  })
-
-  describe("polling cadence", () => {
-    it("polls the overview endpoint every 8s while mounted", async () => {
-      mockOverview.mockResolvedValue(HAPPY_OVERVIEW)
-      vi.useFakeTimers()
-
-      const wrapper = mount(SyncthingView)
-      // Initial load fires synchronously from onMounted (returns a Promise
-      // we need to flush). Do NOT use vi.runOnlyPendingTimersAsync here:
-      // it fires the setInterval's first tick prematurely.
-      await flushPromises()
-      expect(mockOverview).toHaveBeenCalledTimes(1)
-
-      // Just under 8s: no new call yet.
-      await vi.advanceTimersByTimeAsync(7000)
-      expect(mockOverview).toHaveBeenCalledTimes(1)
-
-      // Crossing the 8s boundary fires the next poll.
-      await vi.advanceTimersByTimeAsync(1500)
-      expect(mockOverview).toHaveBeenCalledTimes(2)
-
-      // Another full 8s cycle.
-      await vi.advanceTimersByTimeAsync(8000)
-      expect(mockOverview).toHaveBeenCalledTimes(3)
-
-      wrapper.unmount()
-    })
-
-    it("stops polling after unmount", async () => {
-      mockOverview.mockResolvedValue(HAPPY_OVERVIEW)
-      vi.useFakeTimers()
-
-      const wrapper = mount(SyncthingView)
-      await flushPromises()
-      expect(mockOverview).toHaveBeenCalledTimes(1)
-
-      wrapper.unmount()
-
-      // After unmount, no further polls should land regardless of how
-      // much time passes.
-      await vi.advanceTimersByTimeAsync(30_000)
-      expect(mockOverview).toHaveBeenCalledTimes(1)
-    })
-  })
 })

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,123 +1,139 @@
 import type {
-  HangingFile,
-  IgnoredGrouped,
-  IgnoreKind,
-  Job,
-  MaintenanceCounts,
-  PendingGroup,
-  PendingItemRef,
-  RemoveResponse,
-  ResolveAction,
-  ResolveResponse,
-  ResolveResult,
-  ScrobbleResponse,
-  ScrobbleScope,
-  StateBundle,
-  SyncedEntry,
-  SyncthingOverview,
-  TitleDetail,
-  WatchedFiles,
-  WatchlistEntry,
+    HangingFile,
+    IgnoredGrouped,
+    IgnoreOp,
+    Job,
+    MaintenanceCounts,
+    PendingGroup,
+    PendingItemRef,
+    RemoveResponse,
+    ResolveAction,
+    ResolveResponse,
+    ResolveResult,
+    ScrobbleResponse,
+    ScrobbleScope,
+    StateBundle,
+    SyncedEntry,
+    SyncthingOverview,
+    TitleDetail,
+    WatchedFiles,
+    WatchlistEntry,
 } from "./types"
 
 const BASE = ""
 
 async function json<T>(path: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(BASE + path, {
-    headers: { "Content-Type": "application/json" },
-    ...init,
-  })
-  if (!res.ok) {
-    let body = ""
-    try { body = await res.text() } catch { /* ignore */ }
-    throw new Error(`${res.status} ${path}: ${body}`)
-  }
-  return res.json() as Promise<T>
+    const res = await fetch(BASE + path, {
+        headers: { "Content-Type": "application/json" },
+        ...init,
+    })
+    if (!res.ok) {
+        let body = ""
+        try {
+            body = await res.text()
+        } catch {
+            /* ignore */
+        }
+        throw new Error(`${res.status} ${path}: ${body}`)
+    }
+    return res.json() as Promise<T>
 }
 
 export const api = {
-  state: (refresh = false) => json<StateBundle>(`/api/state${refresh ? "?refresh=true" : ""}`),
-  title: (lib: string, folder: string) =>
-    json<TitleDetail>(`/api/title/${encodeURIComponent(lib)}/${encodeURI(folder)}`),
-  thumbUrl: (lib: string, folder: string) =>
-    `/api/plex/thumb/${encodeURIComponent(lib)}/${encodeURI(folder)}`,
-  artUrl: (lib: string, folder: string) =>
-    `/api/plex/art/${encodeURIComponent(lib)}/${encodeURI(folder)}`,
+    state: (refresh = false) =>
+        json<StateBundle>(`/api/state${refresh ? "?refresh=true" : ""}`),
+    title: (lib: string, folder: string) =>
+        json<TitleDetail>(
+            `/api/title/${encodeURIComponent(lib)}/${encodeURI(folder)}`
+        ),
+    thumbUrl: (lib: string, folder: string) =>
+        `/api/plex/thumb/${encodeURIComponent(lib)}/${encodeURI(folder)}`,
+    artUrl: (lib: string, folder: string) =>
+        `/api/plex/art/${encodeURIComponent(lib)}/${encodeURI(folder)}`,
 
-  sync: (body: SyncBody) =>
-    json<SyncResponse>("/api/sync", { method: "POST", body: JSON.stringify(body) }),
-  unsync: (body: SyncBody) =>
-    json<SyncResponse>("/api/unsync", { method: "POST", body: JSON.stringify(body) }),
+    sync: (body: SyncBody) =>
+        json<SyncResponse>("/api/sync", {
+            method: "POST",
+            body: JSON.stringify(body),
+        }),
+    unsync: (body: SyncBody) =>
+        json<SyncResponse>("/api/unsync", {
+            method: "POST",
+            body: JSON.stringify(body),
+        }),
 
-  job: (id: string) => json<Job>(`/api/jobs/${id}`),
-  jobs: () => json<{ jobs: Job[] }>(`/api/jobs`),
+    job: (id: string) => json<Job>(`/api/jobs/${id}`),
+    jobs: () => json<{ jobs: Job[] }>(`/api/jobs`),
 
-  synced: () => json<{ items: SyncedEntry[] }>(`/api/synced`),
-  watchlist: () => json<{ items: WatchlistEntry[] }>(`/api/watchlist`),
-  maintWatched: () => json<{ items: WatchedFiles[] }>(`/api/maintenance/watched`),
-  maintHanging: () => json<{ items: HangingFile[] }>(`/api/maintenance/hanging`),
-  maintRemove: (paths: string[]) =>
-    json<RemoveResponse>(`/api/maintenance/remove`, {
-      method: "POST",
-      body: JSON.stringify({ paths }),
-    }),
-  maintCounts: () => json<MaintenanceCounts>(`/api/maintenance/counts`),
-  maintIgnored: () => json<IgnoredGrouped>(`/api/maintenance/ignored`),
-  maintIgnore: (kind: IgnoreKind, ref: object) =>
-    json<{ ok: boolean }>(`/api/maintenance/ignore`, {
-      method: "POST",
-      body: JSON.stringify({ kind, ref }),
-    }),
-  maintUnignore: (kind: IgnoreKind, ref: object) =>
-    json<{ ok: boolean }>(`/api/maintenance/unignore`, {
-      method: "POST",
-      body: JSON.stringify({ kind, ref }),
-    }),
-  maintPending: () => json<{ items: PendingGroup[] }>(`/api/maintenance/pending`),
-  maintResolve: (items: PendingItemRef[], action: ResolveAction) =>
-    json<ResolveResponse>(`/api/maintenance/resolve`, {
-      method: "POST",
-      body: JSON.stringify({ items, action }),
-    }),
+    synced: () => json<{ items: SyncedEntry[] }>(`/api/synced`),
+    watchlist: () => json<{ items: WatchlistEntry[] }>(`/api/watchlist`),
+    maintWatched: () =>
+        json<{ items: WatchedFiles[] }>(`/api/maintenance/watched`),
+    maintHanging: () =>
+        json<{ items: HangingFile[] }>(`/api/maintenance/hanging`),
+    maintRemove: (paths: string[]) =>
+        json<RemoveResponse>(`/api/maintenance/remove`, {
+            method: "POST",
+            body: JSON.stringify({ paths }),
+        }),
+    maintCounts: () => json<MaintenanceCounts>(`/api/maintenance/counts`),
+    maintIgnored: () => json<IgnoredGrouped>(`/api/maintenance/ignored`),
+    maintIgnore: (op: IgnoreOp) =>
+        json<{ ok: boolean }>(`/api/maintenance/ignore`, {
+            method: "POST",
+            body: JSON.stringify({ kind: op.kind, ref: op.ref }),
+        }),
+    maintUnignore: (op: IgnoreOp) =>
+        json<{ ok: boolean }>(`/api/maintenance/unignore`, {
+            method: "POST",
+            body: JSON.stringify({ kind: op.kind, ref: op.ref }),
+        }),
+    maintPending: () =>
+        json<{ items: PendingGroup[] }>(`/api/maintenance/pending`),
+    maintResolve: (items: PendingItemRef[], action: ResolveAction) =>
+        json<ResolveResponse>(`/api/maintenance/resolve`, {
+            method: "POST",
+            body: JSON.stringify({ items, action }),
+        }),
 
-  resolve: (url: string) =>
-    json<ResolveResult>("/api/resolve-link", {
-      method: "POST",
-      body: JSON.stringify({ url }),
-    }),
+    resolve: (url: string) =>
+        json<ResolveResult>("/api/resolve-link", {
+            method: "POST",
+            body: JSON.stringify({ url }),
+        }),
 
-  refresh: () => json<{ ok: true }>("/api/refresh", { method: "POST" }),
+    refresh: () => json<{ ok: true }>("/api/refresh", { method: "POST" }),
 
-  scrobble: (body: ScrobbleBody) =>
-    json<ScrobbleResponse>(`/api/scrobble`, {
-      method: "POST",
-      body: JSON.stringify(body),
-    }),
+    scrobble: (body: ScrobbleBody) =>
+        json<ScrobbleResponse>(`/api/scrobble`, {
+            method: "POST",
+            body: JSON.stringify(body),
+        }),
 
-  syncthingOverview: () => json<SyncthingOverview>(`/api/syncthing/overview`),
+    syncthingOverview: () => json<SyncthingOverview>(`/api/syncthing/overview`),
 }
 
 export interface ScrobbleBody {
-  lib: string
-  folder: string
-  scope: ScrobbleScope
-  season?: number
-  episode?: number
+    lib: string
+    folder: string
+    scope: ScrobbleScope
+    season?: number
+    episode?: number
 }
 
 export interface SyncBody {
-  lib: string
-  folder: string
-  selection_type: "all" | "season" | "episodes" | "movie"
-  season?: number
-  episodes?: [number, number][]
-  unwatched_only?: boolean
+    lib: string
+    folder: string
+    selection_type: "all" | "season" | "episodes" | "movie"
+    season?: number
+    episodes?: [number, number][]
+    unwatched_only?: boolean
 }
 
 export interface SyncResponse {
-  job_id: string | null
-  total_files: number
-  total_media_files: number
-  total_bytes: number
-  error?: string
+    job_id: string | null
+    total_files: number
+    total_media_files: number
+    total_bytes: number
+    error?: string
 }

--- a/frontend/src/components/DetailDrawer.vue
+++ b/frontend/src/components/DetailDrawer.vue
@@ -3,13 +3,13 @@ import { computed, onMounted, ref, watch } from "vue"
 import { api } from "../api"
 import type { Episode, TitleDetail } from "../types"
 import {
-  closeDetail,
-  humanSize,
-  isScrobbledThisSession,
-  pushToast,
-  recordScrobbled,
-  store,
-  trackJob,
+    closeDetail,
+    humanSize,
+    isScrobbledThisSession,
+    pushToast,
+    recordScrobbled,
+    store,
+    trackJob,
 } from "../store"
 import EpisodeTile from "./EpisodeTile.vue"
 
@@ -23,12 +23,30 @@ const UNSYNC_REFRESH_DELAY_MS = 1000
 const detail = ref<TitleDetail | null>(null)
 const loading = ref(false)
 const error = ref("")
-const selected = ref<Set<string>>(new Set())   // "S-E"
+const selected = ref<Set<string>>(new Set()) // "S-E"
 const lastClick = ref<{ s: number; e: number } | null>(null)
 const expandedSeasons = ref<Set<number>>(new Set())
 const submitting = ref(false)
 
-function key(s: number, e: number): string { return `${s}-${e}` }
+function key(s: number, e: number): string {
+    return `${s}-${e}`
+}
+
+// Inverse of key(). Keys always come from key() above, so the segments must
+// parse as two numbers. Throws on malformed input — silent fallback would
+// hide a real bug as "season 0 episode 0" syncs.
+function parseKey(k: string): [number, number] {
+    const [s, e] = k.split("-").map(Number)
+    if (
+        s === undefined ||
+        e === undefined ||
+        Number.isNaN(s) ||
+        Number.isNaN(e)
+    ) {
+        throw new Error(`parseKey: malformed selection key "${k}"`)
+    }
+    return [s, e]
+}
 
 // Apply the session scrobble overlay to fresh title-detail data. Plex's
 // scrobble lands instantly but the WatchState daemon polls Plex on a slow
@@ -36,47 +54,55 @@ function key(s: number, e: number): string { return `${s}-${e}` }
 // we successfully scrobbled seconds ago. Without this overlay, the UI would
 // flicker watched -> unwatched as refreshInPlace fires.
 function applyScrobbleOverlay(d: TitleDetail): TitleDetail {
-  if (d.kind === "movie") {
-    if (isScrobbledThisSession(d.lib, d.folder)) d.watched = true
-    return d
-  }
-  for (const s of d.seasons) {
-    let extraWatched = 0
-    for (const e of s.episodes) {
-      if (
-        isScrobbledThisSession(d.lib, d.folder, e.season, e.episode)
-        && e.watch_state !== "watched"
-      ) {
-        e.watch_state = "watched"
-        e.watch_pct = 100
-        extraWatched++
-      }
+    if (d.kind === "movie") {
+        if (isScrobbledThisSession(d.lib, d.folder)) d.watched = true
+        return d
     }
-    s.watched_episodes += extraWatched
-  }
-  return d
+    for (const s of d.seasons) {
+        let extraWatched = 0
+        for (const e of s.episodes) {
+            if (
+                isScrobbledThisSession(d.lib, d.folder, e.season, e.episode) &&
+                e.watch_state !== "watched"
+            ) {
+                e.watch_state = "watched"
+                e.watch_pct = 100
+                extraWatched++
+            }
+        }
+        s.watched_episodes += extraWatched
+    }
+    return d
 }
 
 async function load(lib: string, folder: string): Promise<void> {
-  loading.value = true
-  error.value = ""
-  detail.value = null
-  selected.value = new Set()
-  lastClick.value = null
-  expandedSeasons.value = new Set()
-  try {
-    const d = applyScrobbleOverlay(await api.title(lib, folder))
-    detail.value = d
-    // Expand the first season with unsynced or unwatched eps; otherwise season 1
-    if (d.kind !== "movie" && d.seasons.length) {
-      const seed = d.seasons.find(s => s.synced_episodes < s.episodes.length) ?? d.seasons[0]
-      expandedSeasons.value.add(seed.season)
+    loading.value = true
+    error.value = ""
+    detail.value = null
+    selected.value = new Set()
+    lastClick.value = null
+    expandedSeasons.value = new Set()
+    try {
+        const d = applyScrobbleOverlay(await api.title(lib, folder))
+        detail.value = d
+        // Expand the first season with unsynced or unwatched eps; otherwise
+        // season 1. noUncheckedIndexedAccess means d.seasons[0] is T|undefined,
+        // so capture it once and let the ?? collapse to a defined value.
+        if (d.kind !== "movie") {
+            const first = d.seasons[0]
+            if (first) {
+                const seed =
+                    d.seasons.find(
+                        (s) => s.synced_episodes < s.episodes.length
+                    ) ?? first
+                expandedSeasons.value.add(seed.season)
+            }
+        }
+    } catch (err) {
+        error.value = (err as Error).message
+    } finally {
+        loading.value = false
     }
-  } catch (err) {
-    error.value = (err as Error).message
-  } finally {
-    loading.value = false
-  }
 }
 
 // Pull fresh data for the SAME title without touching UI state. Used after a
@@ -84,611 +110,855 @@ async function load(lib: string, folder: string): Promise<void> {
 // already navigated to a different title, this is a no-op — we don't want to
 // stomp the new title's state.
 async function refreshInPlace(lib: string, folder: string): Promise<void> {
-  if (!detail.value || detail.value.lib !== lib || detail.value.folder !== folder) {
-    return
-  }
-  try {
-    const d = applyScrobbleOverlay(await api.title(lib, folder))
-    if (!detail.value || detail.value.lib !== lib || detail.value.folder !== folder) {
-      return  // user navigated during the fetch
+    if (
+        !detail.value ||
+        detail.value.lib !== lib ||
+        detail.value.folder !== folder
+    ) {
+        return
     }
-    // Merge in-place: only mutate fields that can change as a result of sync ops.
-    detail.value.total_bytes = d.total_bytes
-    detail.value.synced_bytes = d.synced_bytes
-    detail.value.files = d.files
-    if (d.kind !== "movie") {
-      // Build a lookup by season number for quick patching
-      const next: Record<number, typeof d.seasons[number]> = {}
-      for (const s of d.seasons) next[s.season] = s
-      for (const s of detail.value.seasons) {
-        const fresh = next[s.season]
-        if (!fresh) continue
-        s.synced_episodes = fresh.synced_episodes
-        s.watched_episodes = fresh.watched_episodes
-        for (const e of s.episodes) {
-          const freshEp = fresh.episodes.find(
-            x => x.season === e.season && x.episode === e.episode,
-          )
-          if (freshEp) {
-            e.is_synced = freshEp.is_synced
-            e.watch_state = freshEp.watch_state
-            e.watch_pct = freshEp.watch_pct
-          }
+    try {
+        const d = applyScrobbleOverlay(await api.title(lib, folder))
+        if (
+            !detail.value ||
+            detail.value.lib !== lib ||
+            detail.value.folder !== folder
+        ) {
+            return // user navigated during the fetch
         }
-      }
-    } else {
-      detail.value.watched = d.watched
+        // Merge in-place: only mutate fields that can change as a result of sync ops.
+        detail.value.total_bytes = d.total_bytes
+        detail.value.synced_bytes = d.synced_bytes
+        detail.value.files = d.files
+        if (d.kind !== "movie") {
+            // Build a lookup by season number for quick patching
+            const next: Record<number, (typeof d.seasons)[number]> = {}
+            for (const s of d.seasons) next[s.season] = s
+            for (const s of detail.value.seasons) {
+                const fresh = next[s.season]
+                if (!fresh) continue
+                s.synced_episodes = fresh.synced_episodes
+                s.watched_episodes = fresh.watched_episodes
+                for (const e of s.episodes) {
+                    const freshEp = fresh.episodes.find(
+                        (x) => x.season === e.season && x.episode === e.episode
+                    )
+                    if (freshEp) {
+                        e.is_synced = freshEp.is_synced
+                        e.watch_state = freshEp.watch_state
+                        e.watch_pct = freshEp.watch_pct
+                    }
+                }
+            }
+        } else {
+            detail.value.watched = d.watched
+        }
+    } catch {
+        // Silent — user's in-flight interaction takes priority.
     }
-  } catch {
-    // Silent — user's in-flight interaction takes priority.
-  }
 }
 
 onMounted(() => {
-  if (store.detail) load(store.detail.lib, store.detail.folder)
+    if (store.detail) load(store.detail.lib, store.detail.folder)
 })
 
-watch(() => store.detail, v => {
-  if (v) load(v.lib, v.folder)
-})
+watch(
+    () => store.detail,
+    (v) => {
+        if (v) load(v.lib, v.folder)
+    }
+)
 
 function flatEpisodes(): Episode[] {
-  return detail.value?.seasons.flatMap(s => s.episodes) ?? []
+    return detail.value?.seasons.flatMap((s) => s.episodes) ?? []
 }
 
 function toggle(s: number, e: number, shift: boolean): void {
-  const k = key(s, e)
-  if (shift && lastClick.value) {
-    // Range select from lastClick to (s,e)
-    const eps = flatEpisodes()
-    const i1 = eps.findIndex(x => x.season === lastClick.value!.s && x.episode === lastClick.value!.e)
-    const i2 = eps.findIndex(x => x.season === s && x.episode === e)
-    if (i1 >= 0 && i2 >= 0) {
-      const [a, b] = i1 < i2 ? [i1, i2] : [i2, i1]
-      const isOn = selected.value.has(k)
-      for (let i = a; i <= b; i++) {
-        const ep = eps[i]
-        if (isOn) selected.value.delete(key(ep.season, ep.episode))
-        else selected.value.add(key(ep.season, ep.episode))
-      }
+    const k = key(s, e)
+    const last = lastClick.value
+    if (shift && last) {
+        // Range select from lastClick to (s,e). Local const so the closures
+        // below can narrow without a non-null assertion.
+        const eps = flatEpisodes()
+        const i1 = eps.findIndex(
+            (x) => x.season === last.s && x.episode === last.e
+        )
+        const i2 = eps.findIndex((x) => x.season === s && x.episode === e)
+        if (i1 >= 0 && i2 >= 0) {
+            const [a, b] = i1 < i2 ? [i1, i2] : [i2, i1]
+            const isOn = selected.value.has(k)
+            for (let i = a; i <= b; i++) {
+                const ep = eps[i]
+                if (!ep) continue
+                if (isOn) selected.value.delete(key(ep.season, ep.episode))
+                else selected.value.add(key(ep.season, ep.episode))
+            }
+        }
+    } else {
+        if (selected.value.has(k)) selected.value.delete(k)
+        else selected.value.add(k)
     }
-  } else {
-    if (selected.value.has(k)) selected.value.delete(k)
-    else selected.value.add(k)
-  }
-  lastClick.value = { s, e }
-  // Reactivity nudge
-  selected.value = new Set(selected.value)
+    lastClick.value = { s, e }
+    // Reactivity nudge
+    selected.value = new Set(selected.value)
 }
 
 function selectAll(): void {
-  const eps = flatEpisodes()
-  if (selected.value.size === eps.length) selected.value = new Set()
-  else selected.value = new Set(eps.map(e => key(e.season, e.episode)))
+    const eps = flatEpisodes()
+    if (selected.value.size === eps.length) selected.value = new Set()
+    else selected.value = new Set(eps.map((e) => key(e.season, e.episode)))
 }
 
 function selectUnwatchedUnsynced(): void {
-  const eps = flatEpisodes().filter(e => e.watch_state !== "watched" && !e.is_synced)
-  selected.value = new Set(eps.map(e => key(e.season, e.episode)))
-  if (eps[0]) expandedSeasons.value.add(eps[0].season)
+    const eps = flatEpisodes().filter(
+        (e) => e.watch_state !== "watched" && !e.is_synced
+    )
+    selected.value = new Set(eps.map((e) => key(e.season, e.episode)))
+    if (eps[0]) expandedSeasons.value.add(eps[0].season)
 }
 
 function selectSeason(s: number): void {
-  if (!detail.value) return
-  const season = detail.value.seasons.find(x => x.season === s)
-  if (!season) return
-  const keys = season.episodes.map(e => key(e.season, e.episode))
-  const allOn = keys.every(k => selected.value.has(k))
-  if (allOn) for (const k of keys) selected.value.delete(k)
-  else for (const k of keys) selected.value.add(k)
-  selected.value = new Set(selected.value)
+    if (!detail.value) return
+    const season = detail.value.seasons.find((x) => x.season === s)
+    if (!season) return
+    const keys = season.episodes.map((e) => key(e.season, e.episode))
+    const allOn = keys.every((k) => selected.value.has(k))
+    if (allOn) for (const k of keys) selected.value.delete(k)
+    else for (const k of keys) selected.value.add(k)
+    selected.value = new Set(selected.value)
 }
 
 const selectionStats = computed(() => {
-  if (!detail.value) return { count: 0, bytes: 0, syncBytes: 0, unsyncCount: 0 }
-  let bytes = 0
-  let syncBytes = 0  // bytes to copy (not yet synced)
-  let unsyncCount = 0  // count synced (eligible for unsync)
-  for (const s of detail.value.seasons) {
-    for (const e of s.episodes) {
-      if (selected.value.has(key(e.season, e.episode))) {
-        bytes += e.size_bytes
-        if (!e.is_synced) syncBytes += e.size_bytes
-        else unsyncCount++
-      }
+    if (!detail.value)
+        return { count: 0, bytes: 0, syncBytes: 0, unsyncCount: 0 }
+    let bytes = 0
+    let syncBytes = 0 // bytes to copy (not yet synced)
+    let unsyncCount = 0 // count synced (eligible for unsync)
+    for (const s of detail.value.seasons) {
+        for (const e of s.episodes) {
+            if (selected.value.has(key(e.season, e.episode))) {
+                bytes += e.size_bytes
+                if (!e.is_synced) syncBytes += e.size_bytes
+                else unsyncCount++
+            }
+        }
     }
-  }
-  return { count: selected.value.size, bytes, syncBytes, unsyncCount }
+    return { count: selected.value.size, bytes, syncBytes, unsyncCount }
 })
 
 async function doSync(): Promise<void> {
-  if (!detail.value || selected.value.size === 0) return
-  submitting.value = true
-  try {
-    const eps: [number, number][] = Array.from(selected.value).map(k => {
-      const [s, e] = k.split("-").map(Number)
-      return [s, e]
-    })
-    const r = await api.sync({
-      lib: detail.value.lib,
-      folder: detail.value.folder,
-      selection_type: "episodes",
-      episodes: eps,
-    })
-    if (r.job_id) {
-      const lib = detail.value.lib
-      const folder = detail.value.folder
-      trackJob(r.job_id, { action: "Sync", name: detail.value.name, totalMediaFiles: r.total_media_files })
-      // In-place refresh after a short delay so the badges reflect new sync
-      // state without resetting expansion / selection / scroll. Gated on the
-      // user still viewing the same title (see refreshInPlace).
-      setTimeout(() => refreshInPlace(lib, folder), SYNC_REFRESH_DELAY_MS)
-      selected.value = new Set()
+    if (!detail.value || selected.value.size === 0) return
+    submitting.value = true
+    try {
+        const eps: [number, number][] = Array.from(selected.value).map(parseKey)
+        const r = await api.sync({
+            lib: detail.value.lib,
+            folder: detail.value.folder,
+            selection_type: "episodes",
+            episodes: eps,
+        })
+        if (r.job_id) {
+            const lib = detail.value.lib
+            const folder = detail.value.folder
+            trackJob(r.job_id, {
+                action: "Sync",
+                name: detail.value.name,
+                totalMediaFiles: r.total_media_files,
+            })
+            // In-place refresh after a short delay so the badges reflect new sync
+            // state without resetting expansion / selection / scroll. Gated on the
+            // user still viewing the same title (see refreshInPlace).
+            setTimeout(() => refreshInPlace(lib, folder), SYNC_REFRESH_DELAY_MS)
+            selected.value = new Set()
+        }
+    } finally {
+        submitting.value = false
     }
-  } finally {
-    submitting.value = false
-  }
 }
 
 async function doUnsync(): Promise<void> {
-  if (!detail.value || selected.value.size === 0) return
-  submitting.value = true
-  try {
-    const eps: [number, number][] = Array.from(selected.value).map(k => {
-      const [s, e] = k.split("-").map(Number)
-      return [s, e]
-    })
-    const r = await api.unsync({
-      lib: detail.value.lib,
-      folder: detail.value.folder,
-      selection_type: "episodes",
-      episodes: eps,
-    })
-    if (r.job_id) {
-      const lib = detail.value.lib
-      const folder = detail.value.folder
-      trackJob(r.job_id, { action: "Unsync", name: detail.value.name, totalMediaFiles: r.total_media_files })
-      setTimeout(() => refreshInPlace(lib, folder), UNSYNC_REFRESH_DELAY_MS)
-      selected.value = new Set()
+    if (!detail.value || selected.value.size === 0) return
+    submitting.value = true
+    try {
+        const eps: [number, number][] = Array.from(selected.value).map(parseKey)
+        const r = await api.unsync({
+            lib: detail.value.lib,
+            folder: detail.value.folder,
+            selection_type: "episodes",
+            episodes: eps,
+        })
+        if (r.job_id) {
+            const lib = detail.value.lib
+            const folder = detail.value.folder
+            trackJob(r.job_id, {
+                action: "Unsync",
+                name: detail.value.name,
+                totalMediaFiles: r.total_media_files,
+            })
+            setTimeout(
+                () => refreshInPlace(lib, folder),
+                UNSYNC_REFRESH_DELAY_MS
+            )
+            selected.value = new Set()
+        }
+    } finally {
+        submitting.value = false
     }
-  } finally {
-    submitting.value = false
-  }
 }
 
 async function syncMovie(): Promise<void> {
-  if (!detail.value) return
-  submitting.value = true
-  try {
-    const r = await api.sync({
-      lib: detail.value.lib,
-      folder: detail.value.folder,
-      selection_type: "movie",
-    })
-    if (r.job_id) {
-      const lib = detail.value.lib
-      const folder = detail.value.folder
-      trackJob(r.job_id, { action: "Sync", name: detail.value.name, totalMediaFiles: r.total_media_files })
-      setTimeout(() => refreshInPlace(lib, folder), SYNC_REFRESH_DELAY_MS)
+    if (!detail.value) return
+    submitting.value = true
+    try {
+        const r = await api.sync({
+            lib: detail.value.lib,
+            folder: detail.value.folder,
+            selection_type: "movie",
+        })
+        if (r.job_id) {
+            const lib = detail.value.lib
+            const folder = detail.value.folder
+            trackJob(r.job_id, {
+                action: "Sync",
+                name: detail.value.name,
+                totalMediaFiles: r.total_media_files,
+            })
+            setTimeout(() => refreshInPlace(lib, folder), SYNC_REFRESH_DELAY_MS)
+        }
+    } finally {
+        submitting.value = false
     }
-  } finally {
-    submitting.value = false
-  }
 }
 
 async function unsyncMovie(): Promise<void> {
-  if (!detail.value) return
-  submitting.value = true
-  try {
-    const r = await api.unsync({
-      lib: detail.value.lib,
-      folder: detail.value.folder,
-      selection_type: "movie",
-    })
-    if (r.job_id) {
-      const lib = detail.value.lib
-      const folder = detail.value.folder
-      trackJob(r.job_id, { action: "Unsync", name: detail.value.name, totalMediaFiles: r.total_media_files })
-      setTimeout(() => refreshInPlace(lib, folder), UNSYNC_REFRESH_DELAY_MS)
+    if (!detail.value) return
+    submitting.value = true
+    try {
+        const r = await api.unsync({
+            lib: detail.value.lib,
+            folder: detail.value.folder,
+            selection_type: "movie",
+        })
+        if (r.job_id) {
+            const lib = detail.value.lib
+            const folder = detail.value.folder
+            trackJob(r.job_id, {
+                action: "Unsync",
+                name: detail.value.name,
+                totalMediaFiles: r.total_media_files,
+            })
+            setTimeout(
+                () => refreshInPlace(lib, folder),
+                UNSYNC_REFRESH_DELAY_MS
+            )
+        }
+    } finally {
+        submitting.value = false
     }
-  } finally {
-    submitting.value = false
-  }
 }
 
 function toggleSeasonExpand(s: number): void {
-  if (expandedSeasons.value.has(s)) expandedSeasons.value.delete(s)
-  else expandedSeasons.value.add(s)
+    if (expandedSeasons.value.has(s)) expandedSeasons.value.delete(s)
+    else expandedSeasons.value.add(s)
 }
 
 // ── Mark watched (explicit gesture, no file deletion) ──────────────────────
 
 async function markWatched(
-  scope: "movie" | "series" | "season" | "episode",
-  season?: number,
-  episode?: number,
-  confirmLabel?: string,
+    scope: "movie" | "series" | "season" | "episode",
+    season?: number,
+    episode?: number,
+    confirmLabel?: string
 ): Promise<void> {
-  if (!detail.value) return
-  if (confirmLabel) {
-    if (!confirm(`Mark watched: ${confirmLabel}?`)) return
-  }
-  submitting.value = true
-  try {
-    const r = await api.scrobble({
-      lib: detail.value.lib,
-      folder: detail.value.folder,
-      scope,
-      season,
-      episode,
-    })
-    // Record successful scrobbles in the session overlay, then funnel the
-    // optimistic update through the same applyScrobbleOverlay helper that
-    // refreshInPlace uses. One code path = no drift between "fresh-mark
-    // optimistic update" and "post-refresh re-apply."
-    if (detail.value.kind === "movie") {
-      if (r.scrobbled > 0) {
-        recordScrobbled(detail.value.lib, detail.value.folder)
-      }
-    } else {
-      for (const it of r.results) {
-        if (it.status === "ok" && it.season !== null && it.episode !== null) {
-          recordScrobbled(detail.value.lib, detail.value.folder, it.season, it.episode)
+    if (!detail.value) return
+    if (confirmLabel) {
+        if (!confirm(`Mark watched: ${confirmLabel}?`)) return
+    }
+    submitting.value = true
+    try {
+        const r = await api.scrobble({
+            lib: detail.value.lib,
+            folder: detail.value.folder,
+            scope,
+            season,
+            episode,
+        })
+        // Record successful scrobbles in the session overlay, then funnel the
+        // optimistic update through the same applyScrobbleOverlay helper that
+        // refreshInPlace uses. One code path = no drift between "fresh-mark
+        // optimistic update" and "post-refresh re-apply."
+        if (detail.value.kind === "movie") {
+            if (r.scrobbled > 0) {
+                recordScrobbled(detail.value.lib, detail.value.folder)
+            }
+        } else {
+            for (const it of r.results) {
+                if (
+                    it.status === "ok" &&
+                    it.season !== null &&
+                    it.episode !== null
+                ) {
+                    recordScrobbled(
+                        detail.value.lib,
+                        detail.value.folder,
+                        it.season,
+                        it.episode
+                    )
+                }
+            }
         }
-      }
+        applyScrobbleOverlay(detail.value)
+        if (r.error) {
+            pushToast({ kind: "error", text: r.error })
+        } else if (r.failed > 0) {
+            pushToast({
+                kind: "error",
+                text: `Marked ${r.scrobbled} watched, ${r.failed} failed`,
+            })
+        } else {
+            pushToast({
+                kind: "success",
+                text: `Marked ${r.scrobbled} watched`,
+            })
+        }
+        // Let WatchState catch up; this picks up any drift between optimistic and
+        // canonical state without resetting the UI.
+        const lib = detail.value.lib
+        const folder = detail.value.folder
+        setTimeout(() => refreshInPlace(lib, folder), UNSYNC_REFRESH_DELAY_MS)
+    } catch (e) {
+        pushToast({ kind: "error", text: (e as Error).message })
+    } finally {
+        submitting.value = false
     }
-    applyScrobbleOverlay(detail.value)
-    if (r.error) {
-      pushToast({ kind: "error", text: r.error })
-    } else if (r.failed > 0) {
-      pushToast({
-        kind: "error",
-        text: `Marked ${r.scrobbled} watched, ${r.failed} failed`,
-      })
-    } else {
-      pushToast({
-        kind: "success",
-        text: `Marked ${r.scrobbled} watched`,
-      })
-    }
-    // Let WatchState catch up; this picks up any drift between optimistic and
-    // canonical state without resetting the UI.
-    const lib = detail.value.lib
-    const folder = detail.value.folder
-    setTimeout(() => refreshInPlace(lib, folder), UNSYNC_REFRESH_DELAY_MS)
-  } catch (e) {
-    pushToast({ kind: "error", text: (e as Error).message })
-  } finally {
-    submitting.value = false
-  }
 }
 
 function onBackdropClick(e: MouseEvent): void {
-  if ((e.target as HTMLElement).classList.contains("backdrop")) closeDetail()
+    if ((e.target as HTMLElement).classList.contains("backdrop")) closeDetail()
 }
 
 const artUrl = computed(() =>
-  detail.value ? api.artUrl(detail.value.lib, detail.value.folder) : "",
+    detail.value ? api.artUrl(detail.value.lib, detail.value.folder) : ""
 )
-const movieSynced = computed(() =>
-  detail.value?.kind === "movie" && detail.value.synced_bytes > 0,
+const movieSynced = computed(
+    () => detail.value?.kind === "movie" && detail.value.synced_bytes > 0
 )
 </script>
 
 <template>
-  <div class="backdrop" @click="onBackdropClick">
-    <aside class="drawer fade-in">
-      <button class="close" aria-label="Close" @click="closeDetail">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
-      </button>
-
-      <div v-if="loading" class="loading">Loading…</div>
-      <div v-else-if="error" class="error">{{ error }}</div>
-
-      <template v-else-if="detail">
-        <div class="hero">
-          <img class="art" :src="artUrl" alt="" loading="lazy" @error="($event.target as HTMLImageElement).style.display='none'"/>
-          <div class="hero-overlay"></div>
-          <div class="hero-body">
-            <h1 class="title">{{ detail.name }}</h1>
-            <div class="meta">
-              <span v-if="detail.year">{{ detail.year }}</span>
-              <span class="dim">·</span>
-              <span class="dim">{{ detail.lib }}</span>
-              <span v-if="detail.kind !== 'movie'">
-                <span class="dim">·</span>
-                <span>{{ detail.seasons.length }} season{{ detail.seasons.length === 1 ? "" : "s" }}</span>
-              </span>
-              <span class="dim">·</span>
-              <span>{{ humanSize(detail.total_bytes) }}</span>
-              <span v-if="detail.synced_bytes > 0">
-                <span class="dim">·</span>
-                <span class="sync">⬇ {{ humanSize(detail.synced_bytes) }} synced</span>
-              </span>
-            </div>
-          </div>
-        </div>
-
-        <!-- Movie -->
-        <template v-if="detail.kind === 'movie'">
-          <div class="movie-pane">
-            <div class="movie-files">
-              <div v-for="f in detail.files" :key="f.path" class="file-row" :class="{ synced: f.is_synced }">
-                <span class="file-name mono">{{ f.name }}</span>
-                <span class="file-size dim">{{ humanSize(f.size_bytes) }}</span>
-                <span v-if="f.is_synced" class="file-tag sync">⬇</span>
-              </div>
-            </div>
-            <div class="movie-actions">
-              <button v-if="!movieSynced" class="primary" :disabled="submitting" @click="syncMovie">
-                Sync ({{ humanSize(detail.total_bytes) }})
-              </button>
-              <button v-else class="danger" :disabled="submitting" @click="unsyncMovie">
-                Unsync
-              </button>
-              <button
-                v-if="!detail.watched"
-                class="ghost"
-                :disabled="submitting"
-                data-testid="mark-movie-watched"
-                @click="markWatched('movie', undefined, undefined, detail.name)"
-              >
-                Mark watched
-              </button>
-            </div>
-          </div>
-        </template>
-
-        <!-- Show / YouTube -->
-        <template v-else>
-          <div class="actions-row">
-            <button class="ghost" @click="selectAll">
-              {{ selected.size === flatEpisodes().length && flatEpisodes().length > 0 ? "Clear" : "Select all" }}
-            </button>
-            <button class="ghost" @click="selectUnwatchedUnsynced">
-              Unwatched + unsynced
-            </button>
-            <span class="spacer"></span>
-            <button
-              class="ghost"
-              :disabled="submitting"
-              data-testid="mark-series-watched"
-              @click="markWatched('series', undefined, undefined, `entire series ${detail.name}`)"
-            >
-              Mark series watched
-            </button>
-          </div>
-
-          <div class="seasons">
-            <section v-for="s in detail.seasons" :key="s.season" class="season">
-              <header class="season-head" @click="toggleSeasonExpand(s.season)">
-                <span class="chev" :class="{ open: expandedSeasons.has(s.season) }">▸</span>
-                <strong>Season {{ s.season }}</strong>
-                <span class="dim">{{ s.episodes.length }} ep</span>
-                <span class="dim">·</span>
-                <span class="dim">{{ humanSize(s.total_bytes) }}</span>
-                <span v-if="s.watched_episodes" class="tag watched">{{ s.watched_episodes }} ✓</span>
-                <span v-if="s.synced_episodes" class="tag sync">{{ s.synced_episodes }} ⬇</span>
-                <span class="spacer"></span>
-                <button class="ghost mini" @click.stop="selectSeason(s.season)">select</button>
-                <button
-                  class="ghost mini"
-                  :disabled="submitting"
-                  data-testid="mark-season-watched"
-                  @click.stop="markWatched('season', s.season, undefined, `Season ${s.season}`)"
+    <div class="backdrop" @click="onBackdropClick">
+        <aside class="drawer fade-in">
+            <button class="close" aria-label="Close" @click="closeDetail">
+                <svg
+                    width="18"
+                    height="18"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
                 >
-                  ✓ season
-                </button>
-              </header>
-              <div v-show="expandedSeasons.has(s.season)" class="eps">
-                <EpisodeTile
-                  v-for="e in s.episodes"
-                  :key="e.season + '-' + e.episode"
-                  :ep="e"
-                  :selected="selected.has(key(e.season, e.episode))"
-                  @toggle="toggle"
-                  @mark-watched="(season, episode) => markWatched('episode', season, episode)"
-                />
-              </div>
-            </section>
-          </div>
+                    <line x1="18" y1="6" x2="6" y2="18" />
+                    <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+            </button>
 
-          <div v-if="selected.size > 0" class="action-bar fade-in">
-            <div class="selection-info">
-              <strong>{{ selected.size }}</strong> selected
-              <span class="dim">· {{ humanSize(selectionStats.bytes) }}</span>
-            </div>
-            <div class="action-buttons">
-              <button
-                v-if="selectionStats.syncBytes > 0"
-                class="primary"
-                :disabled="submitting"
-                @click="doSync"
-              >
-                Sync ({{ humanSize(selectionStats.syncBytes) }})
-              </button>
-              <button
-                v-if="selectionStats.unsyncCount > 0"
-                class="danger"
-                :disabled="submitting"
-                @click="doUnsync"
-              >
-                Unsync {{ selectionStats.unsyncCount }}
-              </button>
-            </div>
-          </div>
-        </template>
-      </template>
-    </aside>
-  </div>
+            <div v-if="loading" class="loading">Loading…</div>
+            <div v-else-if="error" class="error">{{ error }}</div>
+
+            <template v-else-if="detail">
+                <div class="hero">
+                    <img
+                        class="art"
+                        :src="artUrl"
+                        alt=""
+                        loading="lazy"
+                        @error="
+                            ($event.target as HTMLImageElement).style.display =
+                                'none'
+                        "
+                    />
+                    <div class="hero-overlay"></div>
+                    <div class="hero-body">
+                        <h1 class="title">{{ detail.name }}</h1>
+                        <div class="meta">
+                            <span v-if="detail.year">{{ detail.year }}</span>
+                            <span class="dim">·</span>
+                            <span class="dim">{{ detail.lib }}</span>
+                            <span v-if="detail.kind !== 'movie'">
+                                <span class="dim">·</span>
+                                <span
+                                    >{{ detail.seasons.length }} season{{
+                                        detail.seasons.length === 1 ? "" : "s"
+                                    }}</span
+                                >
+                            </span>
+                            <span class="dim">·</span>
+                            <span>{{ humanSize(detail.total_bytes) }}</span>
+                            <span v-if="detail.synced_bytes > 0">
+                                <span class="dim">·</span>
+                                <span class="sync"
+                                    >⬇
+                                    {{ humanSize(detail.synced_bytes) }}
+                                    synced</span
+                                >
+                            </span>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Movie -->
+                <template v-if="detail.kind === 'movie'">
+                    <div class="movie-pane">
+                        <div class="movie-files">
+                            <div
+                                v-for="f in detail.files"
+                                :key="f.path"
+                                class="file-row"
+                                :class="{ synced: f.is_synced }"
+                            >
+                                <span class="file-name mono">{{ f.name }}</span>
+                                <span class="file-size dim">{{
+                                    humanSize(f.size_bytes)
+                                }}</span>
+                                <span v-if="f.is_synced" class="file-tag sync"
+                                    >⬇</span
+                                >
+                            </div>
+                        </div>
+                        <div class="movie-actions">
+                            <button
+                                v-if="!movieSynced"
+                                class="primary"
+                                :disabled="submitting"
+                                @click="syncMovie"
+                            >
+                                Sync ({{ humanSize(detail.total_bytes) }})
+                            </button>
+                            <button
+                                v-else
+                                class="danger"
+                                :disabled="submitting"
+                                @click="unsyncMovie"
+                            >
+                                Unsync
+                            </button>
+                            <button
+                                v-if="!detail.watched"
+                                class="ghost"
+                                :disabled="submitting"
+                                data-testid="mark-movie-watched"
+                                @click="
+                                    markWatched(
+                                        'movie',
+                                        undefined,
+                                        undefined,
+                                        detail.name
+                                    )
+                                "
+                            >
+                                Mark watched
+                            </button>
+                        </div>
+                    </div>
+                </template>
+
+                <!-- Show / YouTube -->
+                <template v-else>
+                    <div class="actions-row">
+                        <button class="ghost" @click="selectAll">
+                            {{
+                                selected.size === flatEpisodes().length &&
+                                flatEpisodes().length > 0
+                                    ? "Clear"
+                                    : "Select all"
+                            }}
+                        </button>
+                        <button class="ghost" @click="selectUnwatchedUnsynced">
+                            Unwatched + unsynced
+                        </button>
+                        <span class="spacer"></span>
+                        <button
+                            class="ghost"
+                            :disabled="submitting"
+                            data-testid="mark-series-watched"
+                            @click="
+                                markWatched(
+                                    'series',
+                                    undefined,
+                                    undefined,
+                                    `entire series ${detail.name}`
+                                )
+                            "
+                        >
+                            Mark series watched
+                        </button>
+                    </div>
+
+                    <div class="seasons">
+                        <section
+                            v-for="s in detail.seasons"
+                            :key="s.season"
+                            class="season"
+                        >
+                            <header
+                                class="season-head"
+                                @click="toggleSeasonExpand(s.season)"
+                            >
+                                <span
+                                    class="chev"
+                                    :class="{
+                                        open: expandedSeasons.has(s.season),
+                                    }"
+                                    >▸</span
+                                >
+                                <strong>Season {{ s.season }}</strong>
+                                <span class="dim"
+                                    >{{ s.episodes.length }} ep</span
+                                >
+                                <span class="dim">·</span>
+                                <span class="dim">{{
+                                    humanSize(s.total_bytes)
+                                }}</span>
+                                <span
+                                    v-if="s.watched_episodes"
+                                    class="tag watched"
+                                    >{{ s.watched_episodes }} ✓</span
+                                >
+                                <span v-if="s.synced_episodes" class="tag sync"
+                                    >{{ s.synced_episodes }} ⬇</span
+                                >
+                                <span class="spacer"></span>
+                                <button
+                                    class="ghost mini"
+                                    @click.stop="selectSeason(s.season)"
+                                >
+                                    select
+                                </button>
+                                <button
+                                    class="ghost mini"
+                                    :disabled="submitting"
+                                    data-testid="mark-season-watched"
+                                    @click.stop="
+                                        markWatched(
+                                            'season',
+                                            s.season,
+                                            undefined,
+                                            `Season ${s.season}`
+                                        )
+                                    "
+                                >
+                                    ✓ season
+                                </button>
+                            </header>
+                            <div
+                                v-show="expandedSeasons.has(s.season)"
+                                class="eps"
+                            >
+                                <EpisodeTile
+                                    v-for="e in s.episodes"
+                                    :key="e.season + '-' + e.episode"
+                                    :ep="e"
+                                    :selected="
+                                        selected.has(key(e.season, e.episode))
+                                    "
+                                    @toggle="toggle"
+                                    @mark-watched="
+                                        (season, episode) =>
+                                            markWatched(
+                                                'episode',
+                                                season,
+                                                episode
+                                            )
+                                    "
+                                />
+                            </div>
+                        </section>
+                    </div>
+
+                    <div v-if="selected.size > 0" class="action-bar fade-in">
+                        <div class="selection-info">
+                            <strong>{{ selected.size }}</strong> selected
+                            <span class="dim"
+                                >· {{ humanSize(selectionStats.bytes) }}</span
+                            >
+                        </div>
+                        <div class="action-buttons">
+                            <button
+                                v-if="selectionStats.syncBytes > 0"
+                                class="primary"
+                                :disabled="submitting"
+                                @click="doSync"
+                            >
+                                Sync ({{ humanSize(selectionStats.syncBytes) }})
+                            </button>
+                            <button
+                                v-if="selectionStats.unsyncCount > 0"
+                                class="danger"
+                                :disabled="submitting"
+                                @click="doUnsync"
+                            >
+                                Unsync {{ selectionStats.unsyncCount }}
+                            </button>
+                        </div>
+                    </div>
+                </template>
+            </template>
+        </aside>
+    </div>
 </template>
 
 <style scoped>
 .backdrop {
-  position: fixed;
-  inset: 0;
-  z-index: 100;
-  background: rgba(0, 0, 0, 0.55);
-  display: flex;
-  justify-content: flex-end;
-  animation: fade-in 140ms ease-out;
+    position: fixed;
+    inset: 0;
+    z-index: 100;
+    background: rgba(0, 0, 0, 0.55);
+    display: flex;
+    justify-content: flex-end;
+    animation: fade-in 140ms ease-out;
 }
 .drawer {
-  width: 540px;
-  max-width: 100vw;
-  /* dvh accounts for dynamic browser chrome (URL bar, etc.) where
+    width: 540px;
+    max-width: 100vw;
+    /* dvh accounts for dynamic browser chrome (URL bar, etc.) where
      100vh would extend the scroll region beyond the visible viewport,
      leaving the bottom of long content unreachable. 100vh stays as the
      fallback for browsers without dvh support. */
-  height: 100vh;
-  height: 100dvh;
-  /* flex-item with overflow:auto needs min-height:0 to size against its
+    height: 100vh;
+    height: 100dvh;
+    /* flex-item with overflow:auto needs min-height:0 to size against its
      content correctly; without it, deeply-stacked content can render
      past the scroll plane and become unreachable. */
-  min-height: 0;
-  background: var(--bg);
-  border-left: 1px solid var(--border);
-  overflow-y: auto;
-  position: relative;
-  display: flex;
-  flex-direction: column;
+    min-height: 0;
+    background: var(--bg);
+    border-left: 1px solid var(--border);
+    overflow-y: auto;
+    position: relative;
+    display: flex;
+    flex-direction: column;
 }
 .close {
-  position: absolute;
-  top: 10px; right: 10px;
-  z-index: 5;
-  width: 36px; height: 36px;
-  padding: 0;
-  border-radius: 50%;
-  background: rgba(0, 0, 0, 0.55);
-  border-color: transparent;
-  backdrop-filter: blur(8px);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    z-index: 5;
+    width: 36px;
+    height: 36px;
+    padding: 0;
+    border-radius: 50%;
+    background: rgba(0, 0, 0, 0.55);
+    border-color: transparent;
+    backdrop-filter: blur(8px);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
 }
 
-.loading, .error { padding: 4rem 1rem; text-align: center; color: var(--fg-muted); }
-.error { color: var(--danger); }
+.loading,
+.error {
+    padding: 4rem 1rem;
+    text-align: center;
+    color: var(--fg-muted);
+}
+.error {
+    color: var(--danger);
+}
 
 .hero {
-  position: relative;
-  aspect-ratio: 16 / 9;
-  background: linear-gradient(135deg, #1a2030, #2a3349);
-  overflow: hidden;
+    position: relative;
+    aspect-ratio: 16 / 9;
+    background: linear-gradient(135deg, #1a2030, #2a3349);
+    overflow: hidden;
 }
 .art {
-  width: 100%; height: 100%; object-fit: cover; display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
 }
 .hero-overlay {
-  position: absolute; inset: 0;
-  background: linear-gradient(to bottom, rgba(12,14,18,0.2), var(--bg) 95%);
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+        to bottom,
+        rgba(12, 14, 18, 0.2),
+        var(--bg) 95%
+    );
 }
 .hero-body {
-  position: absolute; left: 1rem; right: 1rem; bottom: 1rem;
+    position: absolute;
+    left: 1rem;
+    right: 1rem;
+    bottom: 1rem;
 }
 .title {
-  margin: 0 0 0.2rem;
-  font-size: 1.6rem;
-  line-height: 1.15;
-  font-weight: 700;
-  letter-spacing: -0.015em;
-  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.7);
+    margin: 0 0 0.2rem;
+    font-size: 1.6rem;
+    line-height: 1.15;
+    font-weight: 700;
+    letter-spacing: -0.015em;
+    text-shadow: 0 2px 8px rgba(0, 0, 0, 0.7);
 }
 .meta {
-  font-size: 0.85rem;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.4rem;
-  align-items: center;
-  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.7);
+    font-size: 0.85rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    align-items: center;
+    text-shadow: 0 1px 4px rgba(0, 0, 0, 0.7);
 }
-.meta .sync { color: var(--accent-sync); }
+.meta .sync {
+    color: var(--accent-sync);
+}
 
 .actions-row {
-  padding: 0.8rem 1rem 0;
-  display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
+    padding: 0.8rem 1rem 0;
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
 }
 
 .movie-pane {
-  padding: 1rem;
+    padding: 1rem;
 }
 .movie-files {
-  margin-bottom: 1rem;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  overflow: hidden;
+    margin-bottom: 1rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    overflow: hidden;
 }
 .file-row {
-  display: flex;
-  gap: 0.6rem;
-  padding: 0.55rem 0.7rem;
-  align-items: center;
-  border-bottom: 1px solid var(--border);
-  font-size: 0.85rem;
+    display: flex;
+    gap: 0.6rem;
+    padding: 0.55rem 0.7rem;
+    align-items: center;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.85rem;
 }
-.file-row:last-child { border-bottom: none; }
-.file-row.synced { background: rgba(41, 208, 208, 0.07); }
-.file-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 0.8rem; }
-.file-tag.sync { color: var(--accent-sync); font-weight: 700; }
-.movie-actions { display: flex; gap: 0.5rem; }
-.movie-actions button { padding: 0.7rem 1.1rem; flex: 1; font-size: 0.95rem; }
+.file-row:last-child {
+    border-bottom: none;
+}
+.file-row.synced {
+    background: rgba(41, 208, 208, 0.07);
+}
+.file-name {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 0.8rem;
+}
+.file-tag.sync {
+    color: var(--accent-sync);
+    font-weight: 700;
+}
+.movie-actions {
+    display: flex;
+    gap: 0.5rem;
+}
+.movie-actions button {
+    padding: 0.7rem 1.1rem;
+    flex: 1;
+    font-size: 0.95rem;
+}
 
 .seasons {
-  padding: 0.6rem 1rem 6rem;   /* extra bottom padding for action bar */
+    padding: 0.6rem 1rem 6rem; /* extra bottom padding for action bar */
 }
-.season + .season { margin-top: 0.6rem; }
+.season + .season {
+    margin-top: 0.6rem;
+}
 .season-head {
-  display: flex;
-  align-items: center;
-  gap: 0.45rem;
-  padding: 0.6rem 0.7rem;
-  background: var(--bg-elev);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  cursor: pointer;
-  font-size: 0.9rem;
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.6rem 0.7rem;
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    cursor: pointer;
+    font-size: 0.9rem;
 }
-.season-head:hover { background: var(--bg-hover); }
-.chev { display: inline-block; width: 12px; transition: transform 100ms ease; color: var(--fg-dim); }
-.chev.open { transform: rotate(90deg); }
-.tag { font-size: 0.72rem; padding: 1px 6px; border-radius: 4px; font-weight: 600; }
-.tag.watched { background: rgba(76, 175, 108, 0.18); color: var(--accent-watched); }
-.tag.sync    { background: rgba(41, 208, 208, 0.18); color: var(--accent-sync); }
-.mini { padding: 0.25rem 0.55rem; font-size: 0.78rem; }
+.season-head:hover {
+    background: var(--bg-hover);
+}
+.chev {
+    display: inline-block;
+    width: 12px;
+    transition: transform 100ms ease;
+    color: var(--fg-dim);
+}
+.chev.open {
+    transform: rotate(90deg);
+}
+.tag {
+    font-size: 0.72rem;
+    padding: 1px 6px;
+    border-radius: 4px;
+    font-weight: 600;
+}
+.tag.watched {
+    background: rgba(76, 175, 108, 0.18);
+    color: var(--accent-watched);
+}
+.tag.sync {
+    background: rgba(41, 208, 208, 0.18);
+    color: var(--accent-sync);
+}
+.mini {
+    padding: 0.25rem 0.55rem;
+    font-size: 0.78rem;
+}
 
 .eps {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-  gap: 0.5rem;
-  padding: 0.6rem 0.2rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    gap: 0.5rem;
+    padding: 0.6rem 0.2rem;
 }
 
 .action-bar {
-  position: sticky;
-  bottom: 0;
-  display: flex;
-  align-items: center;
-  gap: 0.8rem;
-  padding: 0.75rem 1rem;
-  background: rgba(12, 14, 18, 0.97);
-  border-top: 1px solid var(--border);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
-  z-index: 4;
+    position: sticky;
+    bottom: 0;
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+    padding: 0.75rem 1rem;
+    background: rgba(12, 14, 18, 0.97);
+    border-top: 1px solid var(--border);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    z-index: 4;
 }
-.selection-info { font-size: 0.9rem; flex: 1; }
-.action-buttons { display: flex; gap: 0.5rem; }
+.selection-info {
+    font-size: 0.9rem;
+    flex: 1;
+}
+.action-buttons {
+    display: flex;
+    gap: 0.5rem;
+}
 
 @media (max-width: 720px) {
-  .drawer { width: 100vw; border-left: none; }
-  .hero { aspect-ratio: 16 / 10; }
-  .title { font-size: 1.3rem; }
-  .eps { grid-template-columns: 1fr 1fr; }
+    .drawer {
+        width: 100vw;
+        border-left: none;
+    }
+    .hero {
+        aspect-ratio: 16 / 10;
+    }
+    .title {
+        font-size: 1.3rem;
+    }
+    .eps {
+        grid-template-columns: 1fr 1fr;
+    }
 }
 @media (max-width: 380px) {
-  .eps { grid-template-columns: 1fr; }
+    .eps {
+        grid-template-columns: 1fr;
+    }
 }
 </style>

--- a/frontend/src/components/EpisodeTile.vue
+++ b/frontend/src/components/EpisodeTile.vue
@@ -4,142 +4,193 @@ import { epCode, humanSize } from "../store"
 
 defineProps<{ ep: Episode; selected: boolean }>()
 defineEmits<{
-  (e: "toggle", season: number, episode: number, shift: boolean): void
-  (e: "mark-watched", season: number, episode: number): void
+    (e: "toggle", season: number, episode: number, shift: boolean): void
+    (e: "mark-watched", season: number, episode: number): void
 }>()
 
-function onKey(e: KeyboardEvent, season: number, episode: number): void {
-  // Enter / Space activate the tile, matching native <button> a11y semantics
-  // that we lost when switching the wrapper from <button> to <div role="button">
-  // (so a Mark-watched <button> can nest inside it — invalid HTML otherwise).
-  if (e.key === "Enter" || e.key === " ") {
-    e.preventDefault()
-    ;(e.currentTarget as HTMLElement).dispatchEvent(
-      new MouseEvent("click", { shiftKey: e.shiftKey, bubbles: true }),
-    )
-  }
+function onKey(e: KeyboardEvent): void {
+    // Enter / Space activate the tile, matching native <button> a11y semantics
+    // that we lost when switching the wrapper from <button> to <div role="button">
+    // (so a Mark-watched <button> can nest inside it — invalid HTML otherwise).
+    if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault()
+        ;(e.currentTarget as HTMLElement).dispatchEvent(
+            new MouseEvent("click", { shiftKey: e.shiftKey, bubbles: true })
+        )
+    }
 }
 </script>
 
 <template>
-  <div
-    role="button"
-    tabindex="0"
-    :class="[
-      'tile',
-      { selected, watched: ep.watch_state === 'watched', synced: ep.is_synced },
-    ]"
-    @click="$emit('toggle', ep.season, ep.episode, ($event as MouseEvent).shiftKey)"
-    @keydown="onKey($event, ep.season, ep.episode)"
-  >
-    <div class="row1">
-      <span class="code mono">{{ epCode(ep.season, ep.episode) }}</span>
-      <span class="state-icons">
-        <span v-if="ep.watch_state === 'watched'" class="ico watched" title="Watched">●</span>
-        <span v-else-if="ep.watch_state === 'progress'" class="ico progress" title="In progress">◐</span>
-        <span v-else class="ico unw" title="Unwatched">○</span>
-        <span v-if="ep.is_synced" class="ico synced" title="Synced">⬇</span>
-      </span>
-    </div>
-    <div class="title" :title="ep.title">{{ ep.title || "—" }}</div>
-    <div class="meta dim">{{ humanSize(ep.size_bytes) }}</div>
-    <button
-      v-if="ep.watch_state !== 'watched'"
-      class="mark-watched-btn"
-      title="Mark watched"
-      data-testid="mark-episode-watched"
-      @click.stop="$emit('mark-watched', ep.season, ep.episode)"
+    <div
+        role="button"
+        tabindex="0"
+        :class="[
+            'tile',
+            {
+                selected,
+                watched: ep.watch_state === 'watched',
+                synced: ep.is_synced,
+            },
+        ]"
+        @click="
+            $emit(
+                'toggle',
+                ep.season,
+                ep.episode,
+                ($event as MouseEvent).shiftKey
+            )
+        "
+        @keydown="onKey($event)"
     >
-      ✓
-    </button>
-  </div>
+        <div class="row1">
+            <span class="code mono">{{ epCode(ep.season, ep.episode) }}</span>
+            <span class="state-icons">
+                <span
+                    v-if="ep.watch_state === 'watched'"
+                    class="ico watched"
+                    title="Watched"
+                    >●</span
+                >
+                <span
+                    v-else-if="ep.watch_state === 'progress'"
+                    class="ico progress"
+                    title="In progress"
+                    >◐</span
+                >
+                <span v-else class="ico unw" title="Unwatched">○</span>
+                <span v-if="ep.is_synced" class="ico synced" title="Synced"
+                    >⬇</span
+                >
+            </span>
+        </div>
+        <div class="title" :title="ep.title">{{ ep.title || "—" }}</div>
+        <div class="meta dim">{{ humanSize(ep.size_bytes) }}</div>
+        <button
+            v-if="ep.watch_state !== 'watched'"
+            class="mark-watched-btn"
+            title="Mark watched"
+            data-testid="mark-episode-watched"
+            @click.stop="$emit('mark-watched', ep.season, ep.episode)"
+        >
+            ✓
+        </button>
+    </div>
 </template>
 
 <style scoped>
 .tile {
-  text-align: left;
-  background: var(--bg-elev);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 0.55rem 0.7rem;
-  cursor: pointer;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  transition: background 100ms ease, border-color 100ms ease;
-  position: relative;
+    text-align: left;
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.55rem 0.7rem;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    transition:
+        background 100ms ease,
+        border-color 100ms ease;
+    position: relative;
 }
-.tile:hover { background: var(--bg-hover); border-color: var(--border-strong); }
+.tile:hover {
+    background: var(--bg-hover);
+    border-color: var(--border-strong);
+}
 .tile.selected {
-  border-color: var(--accent-action);
-  background: rgba(108, 142, 239, 0.10);
-  box-shadow: inset 0 0 0 1px var(--accent-action);
+    border-color: var(--accent-action);
+    background: rgba(108, 142, 239, 0.1);
+    box-shadow: inset 0 0 0 1px var(--accent-action);
 }
-.tile.watched { opacity: 0.65; }
+.tile.watched {
+    opacity: 0.65;
+}
 .tile.synced::after {
-  content: "";
-  position: absolute;
-  left: 0; top: 0; bottom: 0;
-  width: 3px;
-  background: var(--accent-sync);
-  border-radius: var(--radius) 0 0 var(--radius);
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 3px;
+    background: var(--accent-sync);
+    border-radius: var(--radius) 0 0 var(--radius);
 }
 
 .row1 {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 }
 .code {
-  font-size: 0.78rem;
-  font-weight: 600;
-  color: var(--fg-muted);
-  letter-spacing: 0.02em;
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--fg-muted);
+    letter-spacing: 0.02em;
 }
-.state-icons { display: inline-flex; gap: 6px; font-size: 0.8rem; line-height: 1; }
-.ico.watched { color: var(--accent-watched); }
-.ico.progress { color: var(--accent-progress); }
-.ico.unw { color: var(--fg-dim); }
-.ico.synced { color: var(--accent-sync); font-weight: 700; }
+.state-icons {
+    display: inline-flex;
+    gap: 6px;
+    font-size: 0.8rem;
+    line-height: 1;
+}
+.ico.watched {
+    color: var(--accent-watched);
+}
+.ico.progress {
+    color: var(--accent-progress);
+}
+.ico.unw {
+    color: var(--fg-dim);
+}
+.ico.synced {
+    color: var(--accent-sync);
+    font-weight: 700;
+}
 
 .title {
-  font-size: 0.88rem;
-  color: var(--fg);
-  line-height: 1.2;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
+    font-size: 0.88rem;
+    color: var(--fg);
+    line-height: 1.2;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
 }
-.meta { font-size: 0.72rem; }
+.meta {
+    font-size: 0.72rem;
+}
 
 .mark-watched-btn {
-  position: absolute;
-  top: 4px;
-  right: 4px;
-  width: 22px;
-  height: 22px;
-  padding: 0;
-  border-radius: 50%;
-  background: var(--bg);
-  border: 1px solid var(--border);
-  color: var(--fg-muted);
-  font-size: 0.78rem;
-  cursor: pointer;
-  opacity: 0;
-  transition: opacity 80ms ease, background 80ms ease, color 80ms ease;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    border-radius: 50%;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    color: var(--fg-muted);
+    font-size: 0.78rem;
+    cursor: pointer;
+    opacity: 0;
+    transition:
+        opacity 80ms ease,
+        background 80ms ease,
+        color 80ms ease;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
 }
 .tile:hover .mark-watched-btn,
 .tile:focus-within .mark-watched-btn {
-  opacity: 1;
+    opacity: 1;
 }
 .mark-watched-btn:hover {
-  background: var(--accent-watched, #4cc46c);
-  color: var(--bg);
-  border-color: transparent;
+    background: var(--accent-watched, #4cc46c);
+    color: var(--bg);
+    border-color: transparent;
 }
 </style>

--- a/frontend/src/components/FilterBar.vue
+++ b/frontend/src/components/FilterBar.vue
@@ -4,144 +4,175 @@ import { store, filteredTitles } from "../store"
 
 const localQuery = ref(store.query)
 let t: number | undefined
-watch(localQuery, v => {
-  clearTimeout(t)
-  t = setTimeout(() => { store.query = v }, 120) as unknown as number
+watch(localQuery, (v) => {
+    clearTimeout(t)
+    t = setTimeout(() => {
+        store.query = v
+    }, 120)
 })
 
 // Library chips come from the API so backend + frontend agree on the canonical
 // label and order; no hardcoded map to drift.
-const LIBS = computed(() => store.libraries.map(l => ({ id: l.id, label: l.label })))
+const LIBS = computed(() =>
+    store.libraries.map((l) => ({ id: l.id, label: l.label }))
+)
 
 const STATES = [
-  { id: "unwatched", label: "Unwatched", color: "var(--fg-muted)" },
-  { id: "watching",  label: "Watching",  color: "var(--accent-progress)" },
-  { id: "synced",    label: "Synced",    color: "var(--accent-sync)" },
-  { id: "new",       label: "Has new",   color: "var(--accent-progress)" },
+    { id: "unwatched", label: "Unwatched", color: "var(--fg-muted)" },
+    { id: "watching", label: "Watching", color: "var(--accent-progress)" },
+    { id: "synced", label: "Synced", color: "var(--accent-sync)" },
+    { id: "new", label: "Has new", color: "var(--accent-progress)" },
 ]
 
 function toggle(set: Set<string>, id: string): void {
-  if (set.has(id)) set.delete(id)
-  else set.add(id)
+    if (set.has(id)) set.delete(id)
+    else set.add(id)
 }
 </script>
 
 <template>
-  <div class="filter-bar">
-    <div class="search">
-      <svg class="ico" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <circle cx="11" cy="11" r="8"/>
-        <line x1="21" y1="21" x2="16.65" y2="16.65"/>
-      </svg>
-      <input
-        v-model="localQuery"
-        type="search"
-        placeholder="Search library… (fa = Fallout)"
-        autocomplete="off"
-        spellcheck="false"
-      />
-      <span class="count" v-if="store.loaded">{{ filteredTitles.length }}</span>
+    <div class="filter-bar">
+        <div class="search">
+            <svg
+                class="ico"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+            >
+                <circle cx="11" cy="11" r="8" />
+                <line x1="21" y1="21" x2="16.65" y2="16.65" />
+            </svg>
+            <input
+                v-model="localQuery"
+                type="search"
+                placeholder="Search library… (fa = Fallout)"
+                autocomplete="off"
+                spellcheck="false"
+            />
+            <span v-if="store.loaded" class="count">{{
+                filteredTitles.length
+            }}</span>
+        </div>
+
+        <div class="chips">
+            <button
+                v-for="l in LIBS"
+                :key="l.id"
+                :class="['chip', { on: store.libFilter.has(l.id) }]"
+                @click="toggle(store.libFilter, l.id)"
+            >
+                {{ l.label }}
+            </button>
+
+            <span class="div"></span>
+
+            <button
+                v-for="s in STATES"
+                :key="s.id"
+                :class="['chip', 'state', { on: store.stateFilter.has(s.id) }]"
+                :style="{ '--state-color': s.color } as any"
+                @click="toggle(store.stateFilter, s.id)"
+            >
+                <span class="dot" :style="{ background: s.color }"></span>
+                {{ s.label }}
+            </button>
+        </div>
     </div>
-
-    <div class="chips">
-      <button
-        v-for="l in LIBS"
-        :key="l.id"
-        :class="['chip', { on: store.libFilter.has(l.id) }]"
-        @click="toggle(store.libFilter, l.id)"
-      >{{ l.label }}</button>
-
-      <span class="div"></span>
-
-      <button
-        v-for="s in STATES"
-        :key="s.id"
-        :class="['chip', 'state', { on: store.stateFilter.has(s.id) }]"
-        :style="{ '--state-color': s.color } as any"
-        @click="toggle(store.stateFilter, s.id)"
-      >
-        <span class="dot" :style="{ background: s.color }"></span>
-        {{ s.label }}
-      </button>
-    </div>
-  </div>
 </template>
 
 <style scoped>
 .filter-bar {
-  position: sticky;
-  top: 49px;
-  z-index: 40;
-  background: rgba(12, 14, 18, 0.92);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
-  border-bottom: 1px solid var(--border);
-  padding: 0.6rem 1rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.55rem;
+    position: sticky;
+    top: 49px;
+    z-index: 40;
+    background: rgba(12, 14, 18, 0.92);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--border);
+    padding: 0.6rem 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
 }
 
 .search {
-  position: relative;
-  display: flex;
-  align-items: center;
+    position: relative;
+    display: flex;
+    align-items: center;
 }
 .search .ico {
-  position: absolute;
-  left: 0.7rem;
-  color: var(--fg-dim);
-  pointer-events: none;
+    position: absolute;
+    left: 0.7rem;
+    color: var(--fg-dim);
+    pointer-events: none;
 }
 .search input {
-  padding-left: 2.1rem;
-  padding-right: 3.3rem;
-  font-size: 0.95rem;
+    padding-left: 2.1rem;
+    padding-right: 3.3rem;
+    font-size: 0.95rem;
 }
 .search .count {
-  position: absolute;
-  right: 0.6rem;
-  font-size: 0.78rem;
-  color: var(--fg-dim);
-  background: var(--bg-elev);
-  padding: 2px 8px;
-  border-radius: 10px;
+    position: absolute;
+    right: 0.6rem;
+    font-size: 0.78rem;
+    color: var(--fg-dim);
+    background: var(--bg-elev);
+    padding: 2px 8px;
+    border-radius: 10px;
 }
 
 .chips {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.35rem;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.35rem;
 }
 .chip {
-  padding: 0.32rem 0.7rem;
-  font-size: 0.82rem;
-  border-radius: 999px;
-  background: var(--bg-elev);
-  border: 1px solid var(--border);
-  color: var(--fg-muted);
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
+    padding: 0.32rem 0.7rem;
+    font-size: 0.82rem;
+    border-radius: 999px;
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    color: var(--fg-muted);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
 }
-.chip:hover { color: var(--fg); border-color: var(--border-strong); background: var(--bg-elev-2); }
+.chip:hover {
+    color: var(--fg);
+    border-color: var(--border-strong);
+    background: var(--bg-elev-2);
+}
 .chip.on {
-  background: var(--bg-elev-2);
-  border-color: var(--accent-action);
-  color: var(--fg);
+    background: var(--bg-elev-2);
+    border-color: var(--accent-action);
+    color: var(--fg);
 }
-.chip.state.on { border-color: var(--state-color); }
-.chip .dot { width: 7px; height: 7px; border-radius: 50%; }
+.chip.state.on {
+    border-color: var(--state-color);
+}
+.chip .dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+}
 
 .div {
-  width: 1px;
-  height: 18px;
-  background: var(--border);
-  margin: 0 0.25rem;
+    width: 1px;
+    height: 18px;
+    background: var(--border);
+    margin: 0 0.25rem;
 }
 
 @media (max-width: 600px) {
-  .filter-bar { top: 47px; padding: 0.5rem 0.7rem; }
+    .filter-bar {
+        top: 47px;
+        padding: 0.5rem 0.7rem;
+    }
 }
 </style>

--- a/frontend/src/components/JobToasts.vue
+++ b/frontend/src/components/JobToasts.vue
@@ -1,120 +1,196 @@
 <script setup lang="ts">
 import { store, dismissToast } from "../store"
+import type { Job } from "../types"
+import type { Toast } from "../store"
 
 function pct(done: number, total: number): number {
-  if (!total) return 0
-  return Math.min(100, Math.round((done / total) * 100))
+    if (!total) return 0
+    return Math.min(100, Math.round((done / total) * 100))
+}
+
+// Resolve a toast to its running Job, or null. Single source of truth so the
+// template doesn't have to repeat the t.jobId && store.jobs[t.jobId] dance,
+// which fights noUncheckedIndexedAccess.
+function runningJob(t: Toast): Job | null {
+    if (!t.jobId) return null
+    const job = store.jobs[t.jobId]
+    return job?.status === "running" ? job : null
+}
+
+function jobWidth(t: Toast): number {
+    const job = runningJob(t)
+    if (!job) return 0
+    return pct(job.processed_bytes, job.total_bytes)
 }
 </script>
 
 <template>
-  <div class="toasts" :class="{ 'drawer-open': !!store.detail }">
-    <transition-group name="toast">
-      <div
-        v-for="t in store.toasts"
-        :key="t.id"
-        :class="['toast', t.kind]"
-      >
-        <div class="row">
-          <span v-if="t.kind === 'info'" class="spinner"></span>
-          <span v-else-if="t.kind === 'success'" class="ico success">✓</span>
-          <span v-else-if="t.kind === 'error'" class="ico error">!</span>
-          <span class="text">{{ t.text }}</span>
-          <button class="dismiss" @click="dismissToast(t.id)">×</button>
-        </div>
+    <div class="toasts" :class="{ 'drawer-open': !!store.detail }">
+        <transition-group name="toast">
+            <div
+                v-for="t in store.toasts"
+                :key="t.id"
+                :class="['toast', t.kind]"
+            >
+                <div class="row">
+                    <span v-if="t.kind === 'info'" class="spinner"></span>
+                    <span v-else-if="t.kind === 'success'" class="ico success"
+                        >✓</span
+                    >
+                    <span v-else-if="t.kind === 'error'" class="ico error"
+                        >!</span
+                    >
+                    <span class="text">{{ t.text }}</span>
+                    <button class="dismiss" @click="dismissToast(t.id)">
+                        ×
+                    </button>
+                </div>
 
-        <div v-if="t.jobId && store.jobs[t.jobId] && store.jobs[t.jobId].status === 'running'" class="progress">
-          <div
-            class="bar"
-            :style="{ width: pct(store.jobs[t.jobId].processed_bytes, store.jobs[t.jobId].total_bytes) + '%' }"
-          ></div>
-        </div>
-      </div>
-    </transition-group>
-  </div>
+                <div v-if="runningJob(t)" class="progress">
+                    <div
+                        class="bar"
+                        :style="{ width: jobWidth(t) + '%' }"
+                    ></div>
+                </div>
+            </div>
+        </transition-group>
+    </div>
 </template>
 
 <style scoped>
 .toasts {
-  position: fixed;
-  right: 1rem;
-  bottom: 1rem;
-  z-index: 150;
-  display: flex;
-  flex-direction: column;
-  gap: 0.6rem;
-  max-width: 380px;
-  pointer-events: none;
-  transition: right 200ms ease, bottom 200ms ease;
+    position: fixed;
+    right: 1rem;
+    bottom: 1rem;
+    z-index: 150;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    max-width: 380px;
+    pointer-events: none;
+    transition:
+        right 200ms ease,
+        bottom 200ms ease;
 }
 /* Drawer is 540px pinned to the right on desktop — shift toasts left so they
    don't sit on top of the Sync/Unsync buttons in the drawer's action bar. */
 .toasts.drawer-open {
-  right: calc(540px + 1rem);
+    right: calc(540px + 1rem);
 }
 .toast {
-  background: var(--bg-elev-2);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 0.7rem 0.9rem 0.6rem;
-  box-shadow: var(--shadow);
-  pointer-events: auto;
-  font-size: 0.88rem;
+    background: var(--bg-elev-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.7rem 0.9rem 0.6rem;
+    box-shadow: var(--shadow);
+    pointer-events: auto;
+    font-size: 0.88rem;
 }
-.toast.info    { border-color: var(--accent-action); }
-.toast.success { border-color: var(--accent-watched); }
-.toast.error   { border-color: var(--danger); }
+.toast.info {
+    border-color: var(--accent-action);
+}
+.toast.success {
+    border-color: var(--accent-watched);
+}
+.toast.error {
+    border-color: var(--danger);
+}
 
-.row { display: flex; align-items: center; gap: 0.55rem; }
-.text { flex: 1; }
-.ico { font-weight: 700; width: 18px; height: 18px; display: inline-flex; align-items: center; justify-content: center; }
-.ico.success { color: var(--accent-watched); }
-.ico.error   { color: var(--danger); }
+.row {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+}
+.text {
+    flex: 1;
+}
+.ico {
+    font-weight: 700;
+    width: 18px;
+    height: 18px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+.ico.success {
+    color: var(--accent-watched);
+}
+.ico.error {
+    color: var(--danger);
+}
 
 .dismiss {
-  background: transparent;
-  border: none;
-  padding: 0 0.3rem;
-  font-size: 1.1rem;
-  color: var(--fg-dim);
-  cursor: pointer;
-  border-radius: 4px;
+    background: transparent;
+    border: none;
+    padding: 0 0.3rem;
+    font-size: 1.1rem;
+    color: var(--fg-dim);
+    cursor: pointer;
+    border-radius: 4px;
 }
-.dismiss:hover { background: var(--bg-hover); color: var(--fg); }
+.dismiss:hover {
+    background: var(--bg-hover);
+    color: var(--fg);
+}
 
 .spinner {
-  width: 14px; height: 14px;
-  border: 2px solid var(--border);
-  border-top-color: var(--accent-action);
-  border-radius: 50%;
-  animation: spin 0.9s linear infinite;
+    width: 14px;
+    height: 14px;
+    border: 2px solid var(--border);
+    border-top-color: var(--accent-action);
+    border-radius: 50%;
+    animation: spin 0.9s linear infinite;
 }
 
 .progress {
-  margin-top: 0.5rem;
-  height: 3px;
-  background: var(--bg-elev);
-  border-radius: 3px;
-  overflow: hidden;
+    margin-top: 0.5rem;
+    height: 3px;
+    background: var(--bg-elev);
+    border-radius: 3px;
+    overflow: hidden;
 }
 .progress .bar {
-  height: 100%;
-  background: var(--accent-action);
-  transition: width 200ms ease;
+    height: 100%;
+    background: var(--accent-action);
+    transition: width 200ms ease;
 }
 
-.toast-enter-active, .toast-leave-active { transition: opacity 200ms ease, transform 200ms ease; }
-.toast-enter-from { opacity: 0; transform: translateY(10px); }
-.toast-leave-to { opacity: 0; transform: translateX(20px); }
+.toast-enter-active,
+.toast-leave-active {
+    transition:
+        opacity 200ms ease,
+        transform 200ms ease;
+}
+.toast-enter-from {
+    opacity: 0;
+    transform: translateY(10px);
+}
+.toast-leave-to {
+    opacity: 0;
+    transform: translateX(20px);
+}
 
 @media (max-width: 600px) {
-  .toasts { left: 0.6rem; right: 0.6rem; max-width: none; bottom: 0.6rem; }
-  /* Mobile drawer is full-screen; lift toasts above the bottom action bar
+    .toasts {
+        left: 0.6rem;
+        right: 0.6rem;
+        max-width: none;
+        bottom: 0.6rem;
+    }
+    /* Mobile drawer is full-screen; lift toasts above the bottom action bar
      instead of trying to shift them sideways. */
-  .toasts.drawer-open { left: 0.6rem; right: 0.6rem; bottom: 5.5rem; }
+    .toasts.drawer-open {
+        left: 0.6rem;
+        right: 0.6rem;
+        bottom: 5.5rem;
+    }
 }
 @media (min-width: 601px) and (max-width: 720px) {
-  /* Drawer is still full-width here — shift the toast to the top edge instead. */
-  .toasts.drawer-open { right: 1rem; bottom: auto; top: 4.5rem; }
+    /* Drawer is still full-width here — shift the toast to the top edge instead. */
+    .toasts.drawer-open {
+        right: 1rem;
+        bottom: auto;
+        top: 4.5rem;
+    }
 }
 </style>

--- a/frontend/src/components/LinkPasteModal.vue
+++ b/frontend/src/components/LinkPasteModal.vue
@@ -10,114 +10,159 @@ const lastError = ref("")
 const input = ref<HTMLInputElement>()
 
 onMounted(() => {
-  setTimeout(() => input.value?.focus(), 30)
+    setTimeout(() => input.value?.focus(), 30)
 })
 
 async function submit(): Promise<void> {
-  if (!url.value.trim()) return
-  submitting.value = true
-  lastError.value = ""
-  try {
-    const r = await api.resolve(url.value.trim())
-    if (r.found && r.lib && r.folder) {
-      openDetail(r.lib, r.folder)
-      emit("close")
-    } else {
-      lastError.value = reasonLabel(r.reason ?? "no_match")
+    if (!url.value.trim()) return
+    submitting.value = true
+    lastError.value = ""
+    try {
+        const r = await api.resolve(url.value.trim())
+        if (r.found && r.lib && r.folder) {
+            openDetail(r.lib, r.folder)
+            emit("close")
+        } else {
+            lastError.value = reasonLabel(r.reason ?? "no_match")
+        }
+    } catch (e) {
+        lastError.value = (e as Error).message
+    } finally {
+        submitting.value = false
     }
-  } catch (e) {
-    lastError.value = (e as Error).message
-  } finally {
-    submitting.value = false
-  }
 }
 
 function reasonLabel(r: string): string {
-  switch (r) {
-    case "empty":                       return "Type or paste something first."
-    case "imdb_url_unsupported":        return "IMDb URLs aren't supported. Paste the title instead."
-    case "jellyfin_url_unsupported":    return "Jellyfin IDs aren't resolvable. Paste the title instead."
-    case "plex_metadata_lookup_failed": return "Plex couldn't find that metadata key."
-    case "no_match":                    return "No match in your library."
-    default:                            return r
-  }
+    switch (r) {
+        case "empty":
+            return "Type or paste something first."
+        case "imdb_url_unsupported":
+            return "IMDb URLs aren't supported. Paste the title instead."
+        case "jellyfin_url_unsupported":
+            return "Jellyfin IDs aren't resolvable. Paste the title instead."
+        case "plex_metadata_lookup_failed":
+            return "Plex couldn't find that metadata key."
+        case "no_match":
+            return "No match in your library."
+        default:
+            return r
+    }
 }
 
 function paste(): void {
-  navigator.clipboard?.readText().then(t => {
-    if (t) {
-      url.value = t
-      submit()
-    }
-  }).catch(() => {
-    pushToast({ kind: "info", text: "Clipboard not accessible — type or paste manually." })
-  })
+    navigator.clipboard
+        ?.readText()
+        .then((t) => {
+            if (t) {
+                url.value = t
+                submit()
+            }
+        })
+        .catch(() => {
+            pushToast({
+                kind: "info",
+                text: "Clipboard not accessible — type or paste manually.",
+            })
+        })
 }
 </script>
 
 <template>
-  <div class="backdrop" @click.self="emit('close')">
-    <div class="modal fade-in">
-      <header>
-        <h2>Paste a link</h2>
-        <button class="ghost mini" @click="emit('close')">×</button>
-      </header>
-      <p class="help dim">
-        Plex web link (best), or just type a title.
-        <br/>
-        IMDb / Jellyfin URLs not yet resolved — paste the title instead.
-      </p>
-      <form @submit.prevent="submit">
-        <input
-          ref="input"
-          v-model="url"
-          placeholder="https://app.plex.tv/… or “better call saul”"
-          autocomplete="off"
-          spellcheck="false"
-        />
-        <div class="actions">
-          <button type="button" class="ghost" @click="paste">From clipboard</button>
-          <span class="spacer"></span>
-          <button type="submit" class="primary" :disabled="submitting || !url.trim()">
-            {{ submitting ? "Looking up…" : "Find" }}
-          </button>
+    <div class="backdrop" @click.self="emit('close')">
+        <div class="modal fade-in">
+            <header>
+                <h2>Paste a link</h2>
+                <button class="ghost mini" @click="emit('close')">×</button>
+            </header>
+            <p class="help dim">
+                Plex web link (best), or just type a title.
+                <br />
+                IMDb / Jellyfin URLs not yet resolved — paste the title instead.
+            </p>
+            <form @submit.prevent="submit">
+                <input
+                    ref="input"
+                    v-model="url"
+                    placeholder="https://app.plex.tv/… or “better call saul”"
+                    autocomplete="off"
+                    spellcheck="false"
+                />
+                <div class="actions">
+                    <button type="button" class="ghost" @click="paste">
+                        From clipboard
+                    </button>
+                    <span class="spacer"></span>
+                    <button
+                        type="submit"
+                        class="primary"
+                        :disabled="submitting || !url.trim()"
+                    >
+                        {{ submitting ? "Looking up…" : "Find" }}
+                    </button>
+                </div>
+            </form>
+            <p v-if="lastError" class="err">{{ lastError }}</p>
         </div>
-      </form>
-      <p v-if="lastError" class="err">{{ lastError }}</p>
     </div>
-  </div>
 </template>
 
 <style scoped>
 .backdrop {
-  position: fixed;
-  inset: 0;
-  z-index: 110;
-  background: rgba(0,0,0,0.55);
-  display: flex;
-  align-items: flex-start;
-  justify-content: center;
-  padding: 8vh 1rem 1rem;
+    position: fixed;
+    inset: 0;
+    z-index: 110;
+    background: rgba(0, 0, 0, 0.55);
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 8vh 1rem 1rem;
 }
 .modal {
-  width: 520px;
-  max-width: 100%;
-  background: var(--bg-elev);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: 1rem 1.2rem 1.2rem;
-  box-shadow: var(--shadow);
+    width: 520px;
+    max-width: 100%;
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 1rem 1.2rem 1.2rem;
+    box-shadow: var(--shadow);
 }
 header {
-  display: flex; align-items: center; gap: 0.5rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
 }
-h2 { margin: 0; font-size: 1.05rem; font-weight: 600; flex: 1; }
+h2 {
+    margin: 0;
+    font-size: 1.05rem;
+    font-weight: 600;
+    flex: 1;
+}
 
-.mini { padding: 0.2rem 0.55rem; font-size: 1.2rem; line-height: 1; }
-.help { font-size: 0.83rem; margin: 0.4rem 0 0.9rem; line-height: 1.45; }
+.mini {
+    padding: 0.2rem 0.55rem;
+    font-size: 1.2rem;
+    line-height: 1;
+}
+.help {
+    font-size: 0.83rem;
+    margin: 0.4rem 0 0.9rem;
+    line-height: 1.45;
+}
 
-form input { font-size: 0.95rem; }
-.actions { display: flex; gap: 0.5rem; margin-top: 0.75rem; }
-.err { margin: 0.75rem 0 0; color: var(--danger); font-size: 0.85rem; }
-.spacer { flex: 1; }
+form input {
+    font-size: 0.95rem;
+}
+.actions {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 0.75rem;
+}
+.err {
+    margin: 0.75rem 0 0;
+    color: var(--danger);
+    font-size: 0.85rem;
+}
+.spacer {
+    flex: 1;
+}
 </style>

--- a/frontend/src/components/MaintenanceView.vue
+++ b/frontend/src/components/MaintenanceView.vue
@@ -2,23 +2,34 @@
 import { computed, onMounted, ref } from "vue"
 import { api } from "../api"
 import type {
-  CleanupSummary,
-  HangingFile,
-  IgnoredGrouped,
-  IgnoreKind,
-  PendingEpisode,
-  PendingGroup,
-  PendingItemRef,
-  ResolveAction,
-  ResolveItemResult,
-  WatchedFiles,
+    CleanupSummary,
+    HangingFile,
+    IgnoredGrouped,
+    IgnoreOp,
+    PendingEpisode,
+    PendingGroup,
+    PendingItemRef,
+    ResolveAction,
+    ResolveItemResult,
+    WatchedFiles,
 } from "../types"
-import { humanSize, loadMaintenanceCount, loadState, pushToast, store } from "../store"
+import {
+    humanSize,
+    loadMaintenanceCount,
+    loadState,
+    pushToast,
+    store,
+} from "../store"
 
 const watched = ref<WatchedFiles[]>([])
 const hanging = ref<HangingFile[]>([])
 const pending = ref<PendingGroup[]>([])
-const ignoredList = ref<IgnoredGrouped>({ version: 1, pending: [], watched: [], hanging: [] })
+const ignoredList = ref<IgnoredGrouped>({
+    version: 1,
+    pending: [],
+    watched: [],
+    hanging: [],
+})
 const ignoredOpen = ref(false)
 const loading = ref(true)
 const error = ref("")
@@ -29,34 +40,35 @@ const resolving = ref(false)
 const expanded = ref<Set<string>>(new Set())
 
 async function load(): Promise<void> {
-  loading.value = true
-  error.value = ""
-  try {
-    const [w, h, p, ig] = await Promise.all([
-      api.maintWatched(),
-      api.maintHanging(),
-      api.maintPending(),
-      api.maintIgnored(),
-    ])
-    watched.value = w.items
-    hanging.value = h.items
-    pending.value = p.items
-    ignoredList.value = ig
-    // Surface the same counts to the tab badge. Cheap: load() already did
-    // the FS walks the counts endpoint would do; this round-trip just sums
-    // them server-side.
-    loadMaintenanceCount()
-  } catch (e) {
-    error.value = (e as Error).message
-  } finally {
-    loading.value = false
-  }
+    loading.value = true
+    error.value = ""
+    try {
+        const [w, h, p, ig] = await Promise.all([
+            api.maintWatched(),
+            api.maintHanging(),
+            api.maintPending(),
+            api.maintIgnored(),
+        ])
+        watched.value = w.items
+        hanging.value = h.items
+        pending.value = p.items
+        ignoredList.value = ig
+        // Surface the same counts to the tab badge. Cheap: load() already did
+        // the FS walks the counts endpoint would do; this round-trip just sums
+        // them server-side.
+        loadMaintenanceCount()
+    } catch (e) {
+        error.value = (e as Error).message
+    } finally {
+        loading.value = false
+    }
 }
 
-const ignoredCount = computed(() =>
-  ignoredList.value.pending.length
-  + ignoredList.value.watched.length
-  + ignoredList.value.hanging.length
+const ignoredCount = computed(
+    () =>
+        ignoredList.value.pending.length +
+        ignoredList.value.watched.length +
+        ignoredList.value.hanging.length
 )
 
 // Mutate the local lists without re-fetching from the server. The
@@ -64,659 +76,1022 @@ const ignoredCount = computed(() =>
 // the invalidation triggered by the ignore call. Optimistic UI keeps the
 // click snappy; on error we restore the entry and surface the error.
 
-function removePendingLocal(kind: IgnoreKind, ref: any): void {
-  if (kind === "watched") {
-    watched.value = watched.value.filter(
-      w => !(w.lib === ref.lib && w.folder === ref.folder),
-    )
-  } else if (kind === "hanging") {
-    hanging.value = hanging.value.filter(h => h.path !== ref.path)
-  } else if (kind === "pending") {
-    if (ref.season === null || ref.season === undefined) {
-      // Movie-level pending: drop the entire group.
-      pending.value = pending.value.filter(
-        g => !(g.sync_sub === ref.sync_sub && g.folder === ref.folder),
-      )
+function removePendingLocal(op: IgnoreOp): void {
+    if (op.kind === "watched") {
+        const r = op.ref
+        watched.value = watched.value.filter(
+            (w) => !(w.lib === r.lib && w.folder === r.folder)
+        )
+    } else if (op.kind === "hanging") {
+        const r = op.ref
+        hanging.value = hanging.value.filter((h) => h.path !== r.path)
     } else {
-      // Episode-level pending: drop the episode; if the season becomes
-      // empty, drop the season; if the group becomes empty, drop the group.
-      pending.value = pending.value
-        .map(g => {
-          if (g.sync_sub !== ref.sync_sub || g.folder !== ref.folder) return g
-          const seasons = (g.seasons ?? [])
-            .map(s => {
-              if (s.season !== ref.season) return s
-              return { ...s, episodes: s.episodes.filter(e => e.episode !== ref.episode) }
-            })
-            .filter(s => s.episodes.length > 0)
-          return { ...g, seasons }
-        })
-        .filter(g => g.kind === "movie" || (g.seasons?.length ?? 0) > 0)
+        const r = op.ref
+        if (r.season === null || r.season === undefined) {
+            // Movie-level pending: drop the entire group.
+            pending.value = pending.value.filter(
+                (g) => !(g.sync_sub === r.sync_sub && g.folder === r.folder)
+            )
+        } else {
+            // Episode-level pending: drop the episode; if the season becomes
+            // empty, drop the season; if the group becomes empty, drop the group.
+            pending.value = pending.value
+                .map((g) => {
+                    if (g.sync_sub !== r.sync_sub || g.folder !== r.folder)
+                        return g
+                    const seasons = (g.seasons ?? [])
+                        .map((s) => {
+                            if (s.season !== r.season) return s
+                            return {
+                                ...s,
+                                episodes: s.episodes.filter(
+                                    (e) => e.episode !== r.episode
+                                ),
+                            }
+                        })
+                        .filter((s) => s.episodes.length > 0)
+                    return { ...g, seasons }
+                })
+                .filter(
+                    (g) => g.kind === "movie" || (g.seasons?.length ?? 0) > 0
+                )
+        }
     }
-  }
 }
 
-async function ignoreItem(kind: IgnoreKind, ref: any, label: string): Promise<void> {
-  // Snapshot for rollback on error.
-  const snapshot = {
-    watched: watched.value,
-    hanging: hanging.value,
-    pending: pending.value,
-    ignoredList: ignoredList.value,
-  }
-  // Optimistic: drop from source list immediately.
-  removePendingLocal(kind, ref)
-  // Add to the ignored list so the Ignored section reflects it without a refetch.
-  if (kind === "watched") {
-    ignoredList.value = {
-      ...ignoredList.value,
-      watched: [...ignoredList.value.watched, ref],
+async function ignoreItem(op: IgnoreOp, label: string): Promise<void> {
+    // Snapshot for rollback on error.
+    const snapshot = {
+        watched: watched.value,
+        hanging: hanging.value,
+        pending: pending.value,
+        ignoredList: ignoredList.value,
     }
-  } else if (kind === "hanging") {
-    ignoredList.value = {
-      ...ignoredList.value,
-      hanging: [...ignoredList.value.hanging, ref],
+    // Optimistic: drop from source list immediately.
+    removePendingLocal(op)
+    // Add to the ignored list so the Ignored section reflects it without a refetch.
+    if (op.kind === "watched") {
+        ignoredList.value = {
+            ...ignoredList.value,
+            watched: [...ignoredList.value.watched, op.ref],
+        }
+    } else if (op.kind === "hanging") {
+        ignoredList.value = {
+            ...ignoredList.value,
+            hanging: [...ignoredList.value.hanging, op.ref],
+        }
+    } else {
+        const r = op.ref
+        ignoredList.value = {
+            ...ignoredList.value,
+            pending: [
+                ...ignoredList.value.pending,
+                {
+                    sync_sub: r.sync_sub,
+                    folder: r.folder,
+                    season: r.season ?? null,
+                    episode: r.episode ?? null,
+                },
+            ],
+        }
     }
-  } else {
-    ignoredList.value = {
-      ...ignoredList.value,
-      pending: [...ignoredList.value.pending, {
-        sync_sub: ref.sync_sub,
-        folder: ref.folder,
-        season: ref.season ?? null,
-        episode: ref.episode ?? null,
-      }],
+    // Decrement the tab badge locally so it updates instantly.
+    if (typeof store.maintenanceCount === "number") {
+        store.maintenanceCount = Math.max(0, store.maintenanceCount - 1)
     }
-  }
-  // Decrement the tab badge locally so it updates instantly.
-  if (typeof store.maintenanceCount === "number") {
-    store.maintenanceCount = Math.max(0, store.maintenanceCount - 1)
-  }
 
-  try {
-    const r = await api.maintIgnore(kind, ref)
-    if (!r.ok) {
-      // Rollback
-      watched.value = snapshot.watched
-      hanging.value = snapshot.hanging
-      pending.value = snapshot.pending
-      ignoredList.value = snapshot.ignoredList
-      loadMaintenanceCount()
-      pushToast({ kind: "error", text: `Could not ignore ${label}` })
-      return
+    try {
+        const r = await api.maintIgnore(op)
+        if (!r.ok) {
+            // Rollback
+            watched.value = snapshot.watched
+            hanging.value = snapshot.hanging
+            pending.value = snapshot.pending
+            ignoredList.value = snapshot.ignoredList
+            loadMaintenanceCount()
+            pushToast({ kind: "error", text: `Could not ignore ${label}` })
+            return
+        }
+        pushToast({ kind: "success", text: `Ignored ${label}` })
+    } catch (e) {
+        watched.value = snapshot.watched
+        hanging.value = snapshot.hanging
+        pending.value = snapshot.pending
+        ignoredList.value = snapshot.ignoredList
+        loadMaintenanceCount()
+        pushToast({ kind: "error", text: (e as Error).message })
     }
-    pushToast({ kind: "success", text: `Ignored ${label}` })
-  } catch (e) {
-    watched.value = snapshot.watched
-    hanging.value = snapshot.hanging
-    pending.value = snapshot.pending
-    ignoredList.value = snapshot.ignoredList
-    loadMaintenanceCount()
-    pushToast({ kind: "error", text: (e as Error).message })
-  }
 }
 
-async function unignoreItem(kind: IgnoreKind, ref: any, label: string): Promise<void> {
-  // Unignore needs a refetch because the entry has to reappear in its
-  // original source list, and we don't have all the fields (size, files)
-  // locally to reconstruct it.
-  try {
-    const r = await api.maintUnignore(kind, ref)
-    if (!r.ok) {
-      pushToast({ kind: "error", text: `Could not unignore ${label}` })
-      return
+async function unignoreItem(op: IgnoreOp, label: string): Promise<void> {
+    // Unignore needs a refetch because the entry has to reappear in its
+    // original source list, and we don't have all the fields (size, files)
+    // locally to reconstruct it.
+    try {
+        const r = await api.maintUnignore(op)
+        if (!r.ok) {
+            pushToast({ kind: "error", text: `Could not unignore ${label}` })
+            return
+        }
+        pushToast({ kind: "success", text: `Unignored ${label}` })
+        await load()
+    } catch (e) {
+        pushToast({ kind: "error", text: (e as Error).message })
     }
-    pushToast({ kind: "success", text: `Unignored ${label}` })
-    await load()
-  } catch (e) {
-    pushToast({ kind: "error", text: (e as Error).message })
-  }
 }
 
 onMounted(load)
 
 function toggleShow(folder: string): void {
-  if (expanded.value.has(folder)) {
-    expanded.value.delete(folder)
-  } else {
-    expanded.value.add(folder)
-  }
-  // reactive Set: reassign to trigger re-render
-  expanded.value = new Set(expanded.value)
+    if (expanded.value.has(folder)) {
+        expanded.value.delete(folder)
+    } else {
+        expanded.value.add(folder)
+    }
+    // reactive Set: reassign to trigger re-render
+    expanded.value = new Set(expanded.value)
 }
 
 function toggleSeason(folder: string, season: number): void {
-  const key = `${folder}|${season}`
-  if (expanded.value.has(key)) {
-    expanded.value.delete(key)
-  } else {
-    expanded.value.add(key)
-  }
-  expanded.value = new Set(expanded.value)
+    const key = `${folder}|${season}`
+    if (expanded.value.has(key)) {
+        expanded.value.delete(key)
+    } else {
+        expanded.value.add(key)
+    }
+    expanded.value = new Set(expanded.value)
 }
 
 function totalEpisodes(g: PendingGroup): number {
-  return (g.seasons ?? []).reduce((n, s) => n + s.episodes.length, 0)
+    return (g.seasons ?? []).reduce((n, s) => n + s.episodes.length, 0)
 }
 
 function refsForGroup(g: PendingGroup): PendingItemRef[] {
-  if (g.kind === "movie") {
-    return [{ sync_sub: g.sync_sub, folder: g.folder }]
-  }
-  return (g.seasons ?? []).flatMap(s =>
-    s.episodes.map(e => ({
-      sync_sub: g.sync_sub,
-      folder: g.folder,
-      season: e.season,
-      episode: e.episode,
-    }))
-  )
+    if (g.kind === "movie") {
+        return [{ sync_sub: g.sync_sub, folder: g.folder }]
+    }
+    return (g.seasons ?? []).flatMap((s) =>
+        s.episodes.map((e) => ({
+            sync_sub: g.sync_sub,
+            folder: g.folder,
+            season: e.season,
+            episode: e.episode,
+        }))
+    )
 }
 
 function refsForSeason(g: PendingGroup, season: number): PendingItemRef[] {
-  const s = (g.seasons ?? []).find(s => s.season === season)
-  if (!s) return []
-  return s.episodes.map(e => ({
-    sync_sub: g.sync_sub,
-    folder: g.folder,
-    season: e.season,
-    episode: e.episode,
-  }))
+    const s = (g.seasons ?? []).find((s) => s.season === season)
+    if (!s) return []
+    return s.episodes.map((e) => ({
+        sync_sub: g.sync_sub,
+        folder: g.folder,
+        season: e.season,
+        episode: e.episode,
+    }))
 }
 
 function refForEpisode(g: PendingGroup, ep: PendingEpisode): PendingItemRef {
-  return { sync_sub: g.sync_sub, folder: g.folder, season: ep.season, episode: ep.episode }
+    return {
+        sync_sub: g.sync_sub,
+        folder: g.folder,
+        season: ep.season,
+        episode: ep.episode,
+    }
 }
 
 function summarizeResolve(results: ResolveItemResult[]): string {
-  const counts = { ok: 0, scrobble_failed: 0, no_rating_key: 0, rejected: 0 }
-  for (const r of results) counts[r.status] += 1
-  const parts: string[] = []
-  if (counts.ok) parts.push(`${counts.ok} scrobbled`)
-  if (counts.rejected) parts.push(`${counts.rejected} rejected`)
-  if (counts.scrobble_failed) parts.push(`${counts.scrobble_failed} scrobble failed`)
-  if (counts.no_rating_key) parts.push(`${counts.no_rating_key} not found in Plex`)
-  return parts.join(", ") || "no items"
+    const counts = { ok: 0, scrobble_failed: 0, no_rating_key: 0, rejected: 0 }
+    for (const r of results) counts[r.status] += 1
+    const parts: string[] = []
+    if (counts.ok) parts.push(`${counts.ok} scrobbled`)
+    if (counts.rejected) parts.push(`${counts.rejected} rejected`)
+    if (counts.scrobble_failed)
+        parts.push(`${counts.scrobble_failed} scrobble failed`)
+    if (counts.no_rating_key)
+        parts.push(`${counts.no_rating_key} not found in Plex`)
+    return parts.join(", ") || "no items"
 }
 
 function summarizeCleanup(c: CleanupSummary | undefined): string {
-  if (!c || (c.removed_files === 0 && c.removed_dirs === 0)) return ""
-  const parts: string[] = []
-  if (c.removed_files) parts.push(`${c.removed_files} sidecar${c.removed_files === 1 ? "" : "s"}`)
-  if (c.removed_dirs) parts.push(`${c.removed_dirs} folder${c.removed_dirs === 1 ? "" : "s"}`)
-  return ` (cleaned ${parts.join(", ")})`
+    if (!c || (c.removed_files === 0 && c.removed_dirs === 0)) return ""
+    const parts: string[] = []
+    if (c.removed_files)
+        parts.push(
+            `${c.removed_files} sidecar${c.removed_files === 1 ? "" : "s"}`
+        )
+    if (c.removed_dirs)
+        parts.push(`${c.removed_dirs} folder${c.removed_dirs === 1 ? "" : "s"}`)
+    return ` (cleaned ${parts.join(", ")})`
 }
 
 async function resolveItems(
-  items: PendingItemRef[],
-  action: ResolveAction,
-  label: string,
+    items: PendingItemRef[],
+    action: ResolveAction,
+    label: string
 ): Promise<void> {
-  if (items.length === 0) return
-  const verb = action === "confirm" ? "Mark watched" : "Reject"
-  if (!confirm(`${verb} ${items.length} item${items.length === 1 ? "" : "s"}?\n\n${label}`)) {
-    return
-  }
-  resolving.value = true
-  try {
-    const res = await api.maintResolve(items, action)
-    if (res.error) {
-      pushToast({ kind: "error", text: res.error })
-    } else {
-      const anyFailed = res.results.some(
-        r => r.status === "scrobble_failed" || r.status === "no_rating_key"
-      )
-      pushToast({
-        kind: anyFailed ? "error" : "success",
-        text: `${verb}: ${summarizeResolve(res.results)}${summarizeCleanup(res.cleanup)}`,
-      })
+    if (items.length === 0) return
+    const verb = action === "confirm" ? "Mark watched" : "Reject"
+    if (
+        !confirm(
+            `${verb} ${items.length} item${items.length === 1 ? "" : "s"}?\n\n${label}`
+        )
+    ) {
+        return
     }
-    await load()
-    await loadState(true)
-  } catch (e) {
-    pushToast({ kind: "error", text: (e as Error).message })
-  } finally {
-    resolving.value = false
-  }
+    resolving.value = true
+    try {
+        const res = await api.maintResolve(items, action)
+        if (res.error) {
+            pushToast({ kind: "error", text: res.error })
+        } else {
+            const anyFailed = res.results.some(
+                (r) =>
+                    r.status === "scrobble_failed" ||
+                    r.status === "no_rating_key"
+            )
+            pushToast({
+                kind: anyFailed ? "error" : "success",
+                text: `${verb}: ${summarizeResolve(res.results)}${summarizeCleanup(res.cleanup)}`,
+            })
+        }
+        await load()
+        await loadState(true)
+    } catch (e) {
+        pushToast({ kind: "error", text: (e as Error).message })
+    } finally {
+        resolving.value = false
+    }
 }
 
 const totalPendingEpisodes = computed(() =>
-  pending.value.reduce((n, g) => n + (g.kind === "movie" ? 1 : totalEpisodes(g)), 0)
+    pending.value.reduce(
+        (n, g) => n + (g.kind === "movie" ? 1 : totalEpisodes(g)),
+        0
+    )
 )
 
 async function removePaths(paths: string[], label: string): Promise<void> {
-  if (paths.length === 0) return
-  if (!confirm(`Remove ${paths.length} file${paths.length === 1 ? "" : "s"}?\n\n${label}`)) return
-  // Optimistic: drop the matching rows from local state immediately so the
-  // UI updates without waiting for the (cold) re-walk that follows the
-  // server-side cache invalidation. Snapshot for rollback.
-  const pathSet = new Set(paths)
-  const snapshotW = watched.value
-  const snapshotH = hanging.value
-  watched.value = watched.value
-    .map(w => ({ ...w, files: w.files.filter(p => !pathSet.has(p)) }))
-    .filter(w => w.files.length > 0)
-  hanging.value = hanging.value.filter(h => !pathSet.has(h.path))
-  // Approximate badge decrement: number of titles+files dropped from view.
-  const dropped =
-    (snapshotW.length - watched.value.length)
-    + (snapshotH.length - hanging.value.length)
-  if (typeof store.maintenanceCount === "number" && dropped > 0) {
-    store.maintenanceCount = Math.max(0, store.maintenanceCount - dropped)
-  }
-  removing.value = true
-  try {
-    const r = await api.maintRemove(paths)
-    pushToast({
-      kind: "success",
-      text: `Removed ${r.removed} files (${humanSize(r.bytes_freed)})${summarizeCleanup(r.cleanup)}`,
-    })
-    // Refresh state in the background (for the library grid's synced/watched
-    // percentages); not awaited so the maintenance view stays snappy.
-    loadState(true)
-  } catch (e) {
-    // Rollback the optimistic state and surface the error.
-    watched.value = snapshotW
-    hanging.value = snapshotH
-    loadMaintenanceCount()
-    pushToast({ kind: "error", text: (e as Error).message })
-  } finally {
-    removing.value = false
-  }
+    if (paths.length === 0) return
+    if (
+        !confirm(
+            `Remove ${paths.length} file${paths.length === 1 ? "" : "s"}?\n\n${label}`
+        )
+    )
+        return
+    // Optimistic: drop the matching rows from local state immediately so the
+    // UI updates without waiting for the (cold) re-walk that follows the
+    // server-side cache invalidation. Snapshot for rollback.
+    const pathSet = new Set(paths)
+    const snapshotW = watched.value
+    const snapshotH = hanging.value
+    watched.value = watched.value
+        .map((w) => ({ ...w, files: w.files.filter((p) => !pathSet.has(p)) }))
+        .filter((w) => w.files.length > 0)
+    hanging.value = hanging.value.filter((h) => !pathSet.has(h.path))
+    // Approximate badge decrement: number of titles+files dropped from view.
+    const dropped =
+        snapshotW.length -
+        watched.value.length +
+        (snapshotH.length - hanging.value.length)
+    if (typeof store.maintenanceCount === "number" && dropped > 0) {
+        store.maintenanceCount = Math.max(0, store.maintenanceCount - dropped)
+    }
+    removing.value = true
+    try {
+        const r = await api.maintRemove(paths)
+        pushToast({
+            kind: "success",
+            text: `Removed ${r.removed} files (${humanSize(r.bytes_freed)})${summarizeCleanup(r.cleanup)}`,
+        })
+        // Refresh state in the background (for the library grid's synced/watched
+        // percentages); not awaited so the maintenance view stays snappy.
+        loadState(true)
+    } catch (e) {
+        // Rollback the optimistic state and surface the error.
+        watched.value = snapshotW
+        hanging.value = snapshotH
+        loadMaintenanceCount()
+        pushToast({ kind: "error", text: (e as Error).message })
+    } finally {
+        removing.value = false
+    }
 }
 
 function removeAllWatched(): void {
-  const paths = watched.value.flatMap(w => w.files)
-  const total = watched.value.reduce((s, w) => s + w.size_bytes, 0)
-  removePaths(paths, `${watched.value.length} title${watched.value.length === 1 ? "" : "s"} · ${humanSize(total)}`)
+    const paths = watched.value.flatMap((w) => w.files)
+    const total = watched.value.reduce((s, w) => s + w.size_bytes, 0)
+    removePaths(
+        paths,
+        `${watched.value.length} title${watched.value.length === 1 ? "" : "s"} · ${humanSize(total)}`
+    )
 }
 
 function removeAllHanging(): void {
-  const paths = hanging.value.map(h => h.path)
-  const total = hanging.value.reduce((s, h) => s + h.size_bytes, 0)
-  removePaths(paths, `${hanging.value.length} hanging files · ${humanSize(total)}`)
+    const paths = hanging.value.map((h) => h.path)
+    const total = hanging.value.reduce((s, h) => s + h.size_bytes, 0)
+    removePaths(
+        paths,
+        `${hanging.value.length} hanging files · ${humanSize(total)}`
+    )
 }
 
 function totalWatchedBytes(): number {
-  return watched.value.reduce((s, w) => s + w.size_bytes, 0)
+    return watched.value.reduce((s, w) => s + w.size_bytes, 0)
 }
 function totalHangingBytes(): number {
-  return hanging.value.reduce((s, h) => s + h.size_bytes, 0)
+    return hanging.value.reduce((s, h) => s + h.size_bytes, 0)
 }
 </script>
 
 <template>
-  <div class="view fade-in">
-    <div v-if="loading" class="info">Scanning…</div>
-    <div v-else-if="error" class="info err">{{ error }}</div>
+    <div class="view fade-in">
+        <div v-if="loading" class="info">Scanning…</div>
+        <div v-else-if="error" class="info err">{{ error }}</div>
 
-    <template v-else>
-      <section class="panel">
-        <header>
-          <h2>Watched in synced-media</h2>
-          <span class="dim">{{ watched.length }} title{{ watched.length === 1 ? "" : "s" }} · {{ humanSize(totalWatchedBytes()) }}</span>
-          <span class="spacer"></span>
-          <button v-if="watched.length > 0" class="danger" :disabled="removing" @click="removeAllWatched">
-            Remove all
-          </button>
-        </header>
-        <p v-if="watched.length === 0" class="empty">Nothing watched in synced-media. Tidy!</p>
-        <ul v-else>
-          <li v-for="w in watched" :key="w.lib + '/' + w.folder">
-            <span class="name">{{ w.title }}</span>
-            <span class="lib dim">{{ w.lib }}</span>
-            <span class="count dim">{{ w.file_count }} files</span>
-            <span class="size mono dim">{{ humanSize(w.size_bytes) }}</span>
-            <button class="danger mini" :disabled="removing" @click="removePaths(w.files, w.title)">
-              Remove
-            </button>
-            <button
-              class="ghost mini"
-              title="Mute this entry"
-              @click="ignoreItem('watched', { lib: w.lib, folder: w.folder }, w.title)"
-            >
-              Ignore
-            </button>
-          </li>
-        </ul>
-      </section>
-
-      <section class="panel" data-testid="pending-deletions">
-        <header>
-          <h2>Deleted, awaiting Plex sync</h2>
-          <span class="dim">
-            {{ pending.length }} title{{ pending.length === 1 ? "" : "s" }}
-            <template v-if="totalPendingEpisodes !== pending.length">
-              · {{ totalPendingEpisodes }} item{{ totalPendingEpisodes === 1 ? "" : "s" }}
-            </template>
-          </span>
-        </header>
-        <p v-if="pending.length === 0" class="empty">
-          No pending deletions. Synced media matches the snapshot.
-        </p>
-        <ul v-else class="pending-list">
-          <li v-for="g in pending" :key="g.sync_sub + '/' + g.folder" class="group">
-            <!-- Movie: single row, no nesting -->
-            <template v-if="g.kind === 'movie'">
-              <div class="row movie">
-                <span class="name">{{ g.title }}</span>
-                <span v-if="g.already_watched_in_plex" class="badge dim">already watched in Plex</span>
-                <span class="lib dim">{{ g.lib ?? '—' }}</span>
-                <span class="spacer"></span>
-                <button
-                  class="primary mini"
-                  :disabled="resolving"
-                  @click="resolveItems(refsForGroup(g), 'confirm', g.title)"
-                >
-                  Mark watched
-                </button>
-                <button
-                  class="danger mini"
-                  :disabled="resolving"
-                  @click="resolveItems(refsForGroup(g), 'reject', g.title)"
-                >
-                  Reject
-                </button>
-                <button
-                  class="ghost mini"
-                  title="Mute this entry"
-                  @click="ignoreItem('pending', { sync_sub: g.sync_sub, folder: g.folder, season: null, episode: null }, g.title)"
-                >
-                  Ignore
-                </button>
-              </div>
-            </template>
-
-            <!-- Show / YouTube: expandable header + nested seasons -->
-            <template v-else>
-              <div class="row show-header">
-                <button
-                  class="toggle"
-                  :aria-expanded="expanded.has(g.folder)"
-                  @click="toggleShow(g.folder)"
-                >
-                  <span class="caret">{{ expanded.has(g.folder) ? "▾" : "▸" }}</span>
-                  <span class="name">{{ g.title }}</span>
-                </button>
-                <span class="dim">
-                  {{ totalEpisodes(g) }} episode{{ totalEpisodes(g) === 1 ? "" : "s" }}
-                </span>
-                <span class="spacer"></span>
-                <button
-                  class="primary mini"
-                  :disabled="resolving"
-                  @click="resolveItems(refsForGroup(g), 'confirm', `${g.title} (all)`)"
-                >
-                  Mark all watched
-                </button>
-                <button
-                  class="danger mini"
-                  :disabled="resolving"
-                  @click="resolveItems(refsForGroup(g), 'reject', `${g.title} (all)`)"
-                >
-                  Reject all
-                </button>
-              </div>
-              <ul v-if="expanded.has(g.folder)" class="seasons">
-                <li v-for="s in g.seasons ?? []" :key="g.folder + '|' + s.season" class="season">
-                  <div class="row season-header">
-                    <button
-                      class="toggle"
-                      :aria-expanded="expanded.has(`${g.folder}|${s.season}`)"
-                      @click="toggleSeason(g.folder, s.season)"
+        <template v-else>
+            <section class="panel">
+                <header>
+                    <h2>Watched in synced-media</h2>
+                    <span class="dim"
+                        >{{ watched.length }} title{{
+                            watched.length === 1 ? "" : "s"
+                        }}
+                        · {{ humanSize(totalWatchedBytes()) }}</span
                     >
-                      <span class="caret">
-                        {{ expanded.has(`${g.folder}|${s.season}`) ? "▾" : "▸" }}
-                      </span>
-                      <span class="season-label">Season {{ s.season }}</span>
-                    </button>
-                    <span class="dim">
-                      {{ s.episodes.length }} ep{{ s.episodes.length === 1 ? "" : "s" }}
-                    </span>
                     <span class="spacer"></span>
                     <button
-                      class="primary mini"
-                      :disabled="resolving"
-                      @click="resolveItems(refsForSeason(g, s.season), 'confirm', `${g.title} S${s.season}`)"
+                        v-if="watched.length > 0"
+                        class="danger"
+                        :disabled="removing"
+                        @click="removeAllWatched"
                     >
-                      Mark season watched
+                        Remove all
                     </button>
-                    <button
-                      class="danger mini"
-                      :disabled="resolving"
-                      @click="resolveItems(refsForSeason(g, s.season), 'reject', `${g.title} S${s.season}`)"
-                    >
-                      Reject season
-                    </button>
-                  </div>
-                  <ul v-if="expanded.has(`${g.folder}|${s.season}`)" class="episodes">
-                    <li
-                      v-for="e in s.episodes"
-                      :key="`${g.folder}|${e.season}|${e.episode}`"
-                      class="row episode"
-                    >
-                      <span class="ep-code mono">
-                        S{{ String(e.season).padStart(2, "0") }}E{{ String(e.episode).padStart(2, "0") }}
-                      </span>
-                      <span v-if="e.already_watched_in_plex" class="badge dim">
-                        already watched in Plex
-                      </span>
-                      <span class="spacer"></span>
-                      <button
-                        class="primary mini"
-                        :disabled="resolving"
-                        @click="resolveItems([refForEpisode(g, e)], 'confirm', `${g.title} S${e.season}E${e.episode}`)"
-                      >
-                        Mark watched
-                      </button>
-                      <button
-                        class="danger mini"
-                        :disabled="resolving"
-                        @click="resolveItems([refForEpisode(g, e)], 'reject', `${g.title} S${e.season}E${e.episode}`)"
-                      >
-                        Reject
-                      </button>
-                      <button
-                        class="ghost mini"
-                        title="Mute this entry"
-                        @click="ignoreItem('pending', { sync_sub: g.sync_sub, folder: g.folder, season: e.season, episode: e.episode }, `${g.title} S${e.season}E${e.episode}`)"
-                      >
-                        Ignore
-                      </button>
+                </header>
+                <p v-if="watched.length === 0" class="empty">
+                    Nothing watched in synced-media. Tidy!
+                </p>
+                <ul v-else>
+                    <li v-for="w in watched" :key="w.lib + '/' + w.folder">
+                        <span class="name">{{ w.title }}</span>
+                        <span class="lib dim">{{ w.lib }}</span>
+                        <span class="count dim">{{ w.file_count }} files</span>
+                        <span class="size mono dim">{{
+                            humanSize(w.size_bytes)
+                        }}</span>
+                        <button
+                            class="danger mini"
+                            :disabled="removing"
+                            @click="removePaths(w.files, w.title)"
+                        >
+                            Remove
+                        </button>
+                        <button
+                            class="ghost mini"
+                            title="Mute this entry"
+                            @click="
+                                ignoreItem(
+                                    {
+                                        kind: 'watched',
+                                        ref: { lib: w.lib, folder: w.folder },
+                                    },
+                                    w.title
+                                )
+                            "
+                        >
+                            Ignore
+                        </button>
                     </li>
-                  </ul>
-                </li>
-              </ul>
-            </template>
-          </li>
-        </ul>
-      </section>
+                </ul>
+            </section>
 
-      <section class="panel">
-        <header>
-          <h2>Hanging files</h2>
-          <span class="dim">{{ hanging.length }} file{{ hanging.length === 1 ? "" : "s" }} · {{ humanSize(totalHangingBytes()) }}</span>
-          <span class="spacer"></span>
-          <button v-if="hanging.length > 0" class="danger" :disabled="removing" @click="removeAllHanging">
-            Remove all
-          </button>
-        </header>
-        <p v-if="hanging.length === 0" class="empty">No hanging files — every synced item has a source.</p>
-        <ul v-else>
-          <li v-for="h in hanging" :key="h.path">
-            <span class="name mono">{{ h.rel }}</span>
-            <span class="spacer"></span>
-            <span class="size dim mono">{{ humanSize(h.size_bytes) }}</span>
-            <button class="danger mini" :disabled="removing" @click="removePaths([h.path], h.rel)">
-              Remove
-            </button>
-            <button
-              class="ghost mini"
-              title="Mute this entry"
-              @click="ignoreItem('hanging', { path: h.path }, h.rel)"
+            <section class="panel" data-testid="pending-deletions">
+                <header>
+                    <h2>Deleted, awaiting Plex sync</h2>
+                    <span class="dim">
+                        {{ pending.length }} title{{
+                            pending.length === 1 ? "" : "s"
+                        }}
+                        <template
+                            v-if="totalPendingEpisodes !== pending.length"
+                        >
+                            · {{ totalPendingEpisodes }} item{{
+                                totalPendingEpisodes === 1 ? "" : "s"
+                            }}
+                        </template>
+                    </span>
+                </header>
+                <p v-if="pending.length === 0" class="empty">
+                    No pending deletions. Synced media matches the snapshot.
+                </p>
+                <ul v-else class="pending-list">
+                    <li
+                        v-for="g in pending"
+                        :key="g.sync_sub + '/' + g.folder"
+                        class="group"
+                    >
+                        <!-- Movie: single row, no nesting -->
+                        <template v-if="g.kind === 'movie'">
+                            <div class="row movie">
+                                <span class="name">{{ g.title }}</span>
+                                <span
+                                    v-if="g.already_watched_in_plex"
+                                    class="badge dim"
+                                    >already watched in Plex</span
+                                >
+                                <span class="lib dim">{{ g.lib ?? "—" }}</span>
+                                <span class="spacer"></span>
+                                <button
+                                    class="primary mini"
+                                    :disabled="resolving"
+                                    @click="
+                                        resolveItems(
+                                            refsForGroup(g),
+                                            'confirm',
+                                            g.title
+                                        )
+                                    "
+                                >
+                                    Mark watched
+                                </button>
+                                <button
+                                    class="danger mini"
+                                    :disabled="resolving"
+                                    @click="
+                                        resolveItems(
+                                            refsForGroup(g),
+                                            'reject',
+                                            g.title
+                                        )
+                                    "
+                                >
+                                    Reject
+                                </button>
+                                <button
+                                    class="ghost mini"
+                                    title="Mute this entry"
+                                    @click="
+                                        ignoreItem(
+                                            {
+                                                kind: 'pending',
+                                                ref: {
+                                                    sync_sub: g.sync_sub,
+                                                    folder: g.folder,
+                                                    season: null,
+                                                    episode: null,
+                                                },
+                                            },
+                                            g.title
+                                        )
+                                    "
+                                >
+                                    Ignore
+                                </button>
+                            </div>
+                        </template>
+
+                        <!-- Show / YouTube: expandable header + nested seasons -->
+                        <template v-else>
+                            <div class="row show-header">
+                                <button
+                                    class="toggle"
+                                    :aria-expanded="expanded.has(g.folder)"
+                                    @click="toggleShow(g.folder)"
+                                >
+                                    <span class="caret">{{
+                                        expanded.has(g.folder) ? "▾" : "▸"
+                                    }}</span>
+                                    <span class="name">{{ g.title }}</span>
+                                </button>
+                                <span class="dim">
+                                    {{ totalEpisodes(g) }} episode{{
+                                        totalEpisodes(g) === 1 ? "" : "s"
+                                    }}
+                                </span>
+                                <span class="spacer"></span>
+                                <button
+                                    class="primary mini"
+                                    :disabled="resolving"
+                                    @click="
+                                        resolveItems(
+                                            refsForGroup(g),
+                                            'confirm',
+                                            `${g.title} (all)`
+                                        )
+                                    "
+                                >
+                                    Mark all watched
+                                </button>
+                                <button
+                                    class="danger mini"
+                                    :disabled="resolving"
+                                    @click="
+                                        resolveItems(
+                                            refsForGroup(g),
+                                            'reject',
+                                            `${g.title} (all)`
+                                        )
+                                    "
+                                >
+                                    Reject all
+                                </button>
+                            </div>
+                            <ul v-if="expanded.has(g.folder)" class="seasons">
+                                <li
+                                    v-for="s in g.seasons ?? []"
+                                    :key="g.folder + '|' + s.season"
+                                    class="season"
+                                >
+                                    <div class="row season-header">
+                                        <button
+                                            class="toggle"
+                                            :aria-expanded="
+                                                expanded.has(
+                                                    `${g.folder}|${s.season}`
+                                                )
+                                            "
+                                            @click="
+                                                toggleSeason(g.folder, s.season)
+                                            "
+                                        >
+                                            <span class="caret">
+                                                {{
+                                                    expanded.has(
+                                                        `${g.folder}|${s.season}`
+                                                    )
+                                                        ? "▾"
+                                                        : "▸"
+                                                }}
+                                            </span>
+                                            <span class="season-label"
+                                                >Season {{ s.season }}</span
+                                            >
+                                        </button>
+                                        <span class="dim">
+                                            {{ s.episodes.length }} ep{{
+                                                s.episodes.length === 1
+                                                    ? ""
+                                                    : "s"
+                                            }}
+                                        </span>
+                                        <span class="spacer"></span>
+                                        <button
+                                            class="primary mini"
+                                            :disabled="resolving"
+                                            @click="
+                                                resolveItems(
+                                                    refsForSeason(g, s.season),
+                                                    'confirm',
+                                                    `${g.title} S${s.season}`
+                                                )
+                                            "
+                                        >
+                                            Mark season watched
+                                        </button>
+                                        <button
+                                            class="danger mini"
+                                            :disabled="resolving"
+                                            @click="
+                                                resolveItems(
+                                                    refsForSeason(g, s.season),
+                                                    'reject',
+                                                    `${g.title} S${s.season}`
+                                                )
+                                            "
+                                        >
+                                            Reject season
+                                        </button>
+                                    </div>
+                                    <ul
+                                        v-if="
+                                            expanded.has(
+                                                `${g.folder}|${s.season}`
+                                            )
+                                        "
+                                        class="episodes"
+                                    >
+                                        <li
+                                            v-for="e in s.episodes"
+                                            :key="`${g.folder}|${e.season}|${e.episode}`"
+                                            class="row episode"
+                                        >
+                                            <span class="ep-code mono">
+                                                S{{
+                                                    String(e.season).padStart(
+                                                        2,
+                                                        "0"
+                                                    )
+                                                }}E{{
+                                                    String(e.episode).padStart(
+                                                        2,
+                                                        "0"
+                                                    )
+                                                }}
+                                            </span>
+                                            <span
+                                                v-if="e.already_watched_in_plex"
+                                                class="badge dim"
+                                            >
+                                                already watched in Plex
+                                            </span>
+                                            <span class="spacer"></span>
+                                            <button
+                                                class="primary mini"
+                                                :disabled="resolving"
+                                                @click="
+                                                    resolveItems(
+                                                        [refForEpisode(g, e)],
+                                                        'confirm',
+                                                        `${g.title} S${e.season}E${e.episode}`
+                                                    )
+                                                "
+                                            >
+                                                Mark watched
+                                            </button>
+                                            <button
+                                                class="danger mini"
+                                                :disabled="resolving"
+                                                @click="
+                                                    resolveItems(
+                                                        [refForEpisode(g, e)],
+                                                        'reject',
+                                                        `${g.title} S${e.season}E${e.episode}`
+                                                    )
+                                                "
+                                            >
+                                                Reject
+                                            </button>
+                                            <button
+                                                class="ghost mini"
+                                                title="Mute this entry"
+                                                @click="
+                                                    ignoreItem(
+                                                        {
+                                                            kind: 'pending',
+                                                            ref: {
+                                                                sync_sub:
+                                                                    g.sync_sub,
+                                                                folder: g.folder,
+                                                                season: e.season,
+                                                                episode:
+                                                                    e.episode,
+                                                            },
+                                                        },
+                                                        `${g.title} S${e.season}E${e.episode}`
+                                                    )
+                                                "
+                                            >
+                                                Ignore
+                                            </button>
+                                        </li>
+                                    </ul>
+                                </li>
+                            </ul>
+                        </template>
+                    </li>
+                </ul>
+            </section>
+
+            <section class="panel">
+                <header>
+                    <h2>Hanging files</h2>
+                    <span class="dim"
+                        >{{ hanging.length }} file{{
+                            hanging.length === 1 ? "" : "s"
+                        }}
+                        · {{ humanSize(totalHangingBytes()) }}</span
+                    >
+                    <span class="spacer"></span>
+                    <button
+                        v-if="hanging.length > 0"
+                        class="danger"
+                        :disabled="removing"
+                        @click="removeAllHanging"
+                    >
+                        Remove all
+                    </button>
+                </header>
+                <p v-if="hanging.length === 0" class="empty">
+                    No hanging files — every synced item has a source.
+                </p>
+                <ul v-else>
+                    <li v-for="h in hanging" :key="h.path">
+                        <span class="name mono">{{ h.rel }}</span>
+                        <span class="spacer"></span>
+                        <span class="size dim mono">{{
+                            humanSize(h.size_bytes)
+                        }}</span>
+                        <button
+                            class="danger mini"
+                            :disabled="removing"
+                            @click="removePaths([h.path], h.rel)"
+                        >
+                            Remove
+                        </button>
+                        <button
+                            class="ghost mini"
+                            title="Mute this entry"
+                            @click="
+                                ignoreItem(
+                                    { kind: 'hanging', ref: { path: h.path } },
+                                    h.rel
+                                )
+                            "
+                        >
+                            Ignore
+                        </button>
+                    </li>
+                </ul>
+            </section>
+
+            <section
+                v-if="ignoredCount > 0"
+                class="panel"
+                data-testid="ignored-section"
             >
-              Ignore
-            </button>
-          </li>
-        </ul>
-      </section>
-
-      <section v-if="ignoredCount > 0" class="panel" data-testid="ignored-section">
-        <header>
-          <h2>
-            <button class="toggle" :aria-expanded="ignoredOpen" @click="ignoredOpen = !ignoredOpen">
-              <span class="caret">{{ ignoredOpen ? "▾" : "▸" }}</span>
-              Ignored
-            </button>
-          </h2>
-          <span class="dim">{{ ignoredCount }} muted</span>
-        </header>
-        <div v-if="ignoredOpen">
-          <ul v-if="ignoredList.pending.length">
-            <li v-for="p in ignoredList.pending" :key="`p-${p.sync_sub}-${p.folder}-${p.season}-${p.episode}`">
-              <span class="kind-tag dim">pending</span>
-              <span class="name">
-                {{ p.folder }}
-                <span v-if="p.season !== null && p.episode !== null" class="dim mono">
-                  S{{ String(p.season).padStart(2, "0") }}E{{ String(p.episode).padStart(2, "0") }}
-                </span>
-              </span>
-              <span class="spacer"></span>
-              <button
-                class="ghost mini"
-                @click="unignoreItem('pending', p, p.folder)"
-              >
-                Unignore
-              </button>
-            </li>
-          </ul>
-          <ul v-if="ignoredList.watched.length">
-            <li v-for="w in ignoredList.watched" :key="`w-${w.lib}-${w.folder}`">
-              <span class="kind-tag dim">watched</span>
-              <span class="name">{{ w.folder }}</span>
-              <span class="lib dim">{{ w.lib }}</span>
-              <span class="spacer"></span>
-              <button
-                class="ghost mini"
-                @click="unignoreItem('watched', w, w.folder)"
-              >
-                Unignore
-              </button>
-            </li>
-          </ul>
-          <ul v-if="ignoredList.hanging.length">
-            <li v-for="h in ignoredList.hanging" :key="`h-${h.path}`">
-              <span class="kind-tag dim">hanging</span>
-              <span class="name mono">{{ h.path }}</span>
-              <span class="spacer"></span>
-              <button
-                class="ghost mini"
-                @click="unignoreItem('hanging', h, h.path)"
-              >
-                Unignore
-              </button>
-            </li>
-          </ul>
-        </div>
-      </section>
-    </template>
-  </div>
+                <header>
+                    <h2>
+                        <button
+                            class="toggle"
+                            :aria-expanded="ignoredOpen"
+                            @click="ignoredOpen = !ignoredOpen"
+                        >
+                            <span class="caret">{{
+                                ignoredOpen ? "▾" : "▸"
+                            }}</span>
+                            Ignored
+                        </button>
+                    </h2>
+                    <span class="dim">{{ ignoredCount }} muted</span>
+                </header>
+                <div v-if="ignoredOpen">
+                    <ul v-if="ignoredList.pending.length">
+                        <li
+                            v-for="p in ignoredList.pending"
+                            :key="`p-${p.sync_sub}-${p.folder}-${p.season}-${p.episode}`"
+                        >
+                            <span class="kind-tag dim">pending</span>
+                            <span class="name">
+                                {{ p.folder }}
+                                <span
+                                    v-if="
+                                        p.season !== null && p.episode !== null
+                                    "
+                                    class="dim mono"
+                                >
+                                    S{{ String(p.season).padStart(2, "0") }}E{{
+                                        String(p.episode).padStart(2, "0")
+                                    }}
+                                </span>
+                            </span>
+                            <span class="spacer"></span>
+                            <button
+                                class="ghost mini"
+                                @click="
+                                    unignoreItem(
+                                        { kind: 'pending', ref: p },
+                                        p.folder
+                                    )
+                                "
+                            >
+                                Unignore
+                            </button>
+                        </li>
+                    </ul>
+                    <ul v-if="ignoredList.watched.length">
+                        <li
+                            v-for="w in ignoredList.watched"
+                            :key="`w-${w.lib}-${w.folder}`"
+                        >
+                            <span class="kind-tag dim">watched</span>
+                            <span class="name">{{ w.folder }}</span>
+                            <span class="lib dim">{{ w.lib }}</span>
+                            <span class="spacer"></span>
+                            <button
+                                class="ghost mini"
+                                @click="
+                                    unignoreItem(
+                                        { kind: 'watched', ref: w },
+                                        w.folder
+                                    )
+                                "
+                            >
+                                Unignore
+                            </button>
+                        </li>
+                    </ul>
+                    <ul v-if="ignoredList.hanging.length">
+                        <li
+                            v-for="h in ignoredList.hanging"
+                            :key="`h-${h.path}`"
+                        >
+                            <span class="kind-tag dim">hanging</span>
+                            <span class="name mono">{{ h.path }}</span>
+                            <span class="spacer"></span>
+                            <button
+                                class="ghost mini"
+                                @click="
+                                    unignoreItem(
+                                        { kind: 'hanging', ref: h },
+                                        h.path
+                                    )
+                                "
+                            >
+                                Unignore
+                            </button>
+                        </li>
+                    </ul>
+                </div>
+            </section>
+        </template>
+    </div>
 </template>
 
 <style scoped>
-.view { padding: 1rem; overflow-y: auto; flex: 1; max-width: 1100px; margin: 0 auto; width: 100%; }
-.info { padding: 3rem 1rem; text-align: center; color: var(--fg-muted); }
-.info.err { color: var(--danger); }
+.view {
+    padding: 1rem;
+    overflow-y: auto;
+    flex: 1;
+    max-width: 1100px;
+    margin: 0 auto;
+    width: 100%;
+}
+.info {
+    padding: 3rem 1rem;
+    text-align: center;
+    color: var(--fg-muted);
+}
+.info.err {
+    color: var(--danger);
+}
 
 .panel {
-  background: var(--bg-elev);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  margin-bottom: 1rem;
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    margin-bottom: 1rem;
 }
 .panel header {
-  display: flex; align-items: center; gap: 0.7rem;
-  padding: 0.75rem 1rem;
-  border-bottom: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--border);
 }
-.panel h2 { margin: 0; font-size: 1rem; font-weight: 600; }
+.panel h2 {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+}
 
-.empty { padding: 1.2rem 1rem; color: var(--fg-muted); margin: 0; }
-ul { list-style: none; padding: 0; margin: 0; }
-li {
-  display: flex; align-items: center; gap: 0.7rem;
-  padding: 0.55rem 1rem;
-  border-bottom: 1px solid var(--border);
-  font-size: 0.88rem;
+.empty {
+    padding: 1.2rem 1rem;
+    color: var(--fg-muted);
+    margin: 0;
 }
-li:last-child { border-bottom: none; }
-.name { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
-.size, .count { font-size: 0.78rem; }
-.mini { padding: 0.25rem 0.55rem; font-size: 0.78rem; }
-.spacer { flex: 1; }
+ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+li {
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    padding: 0.55rem 1rem;
+    border-bottom: 1px solid var(--border);
+    font-size: 0.88rem;
+}
+li:last-child {
+    border-bottom: none;
+}
+.name {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.size,
+.count {
+    font-size: 0.78rem;
+}
+.mini {
+    padding: 0.25rem 0.55rem;
+    font-size: 0.78rem;
+}
+.spacer {
+    flex: 1;
+}
 
 @media (max-width: 600px) {
-  li { flex-wrap: wrap; }
-  .name { flex: 1 1 100%; }
+    li {
+        flex-wrap: wrap;
+    }
+    .name {
+        flex: 1 1 100%;
+    }
 }
 
 /* ── Pending-deletions pane ──────────────────────────────────────────── */
 
-.pending-list { display: flex; flex-direction: column; }
-.pending-list > li.group {
-  display: block;
-  padding: 0;
-  border-bottom: 1px solid var(--border);
+.pending-list {
+    display: flex;
+    flex-direction: column;
 }
-.pending-list > li.group:last-child { border-bottom: none; }
+.pending-list > li.group {
+    display: block;
+    padding: 0;
+    border-bottom: 1px solid var(--border);
+}
+.pending-list > li.group:last-child {
+    border-bottom: none;
+}
 
 .row {
-  display: flex; align-items: center; gap: 0.7rem;
-  padding: 0.55rem 1rem;
-  font-size: 0.88rem;
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    padding: 0.55rem 1rem;
+    font-size: 0.88rem;
 }
-.row.show-header { font-weight: 500; }
-.row.season-header { padding-left: 2rem; background: var(--bg-elev); }
-.row.episode { padding-left: 3rem; font-size: 0.83rem; }
+.row.show-header {
+    font-weight: 500;
+}
+.row.season-header {
+    padding-left: 2rem;
+    background: var(--bg-elev);
+}
+.row.episode {
+    padding-left: 3rem;
+    font-size: 0.83rem;
+}
 
 .toggle {
-  display: inline-flex; align-items: center; gap: 0.4rem;
-  background: none; border: none; color: inherit; cursor: pointer;
-  padding: 0; font: inherit; text-align: left;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    background: none;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    padding: 0;
+    font: inherit;
+    text-align: left;
 }
-.caret { width: 0.9rem; display: inline-block; color: var(--fg-muted); }
+.caret {
+    width: 0.9rem;
+    display: inline-block;
+    color: var(--fg-muted);
+}
 
-.seasons, .episodes { list-style: none; padding: 0; margin: 0; }
-.seasons > li.season { border-top: 1px solid var(--border); }
+.seasons,
+.episodes {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+.seasons > li.season {
+    border-top: 1px solid var(--border);
+}
 
 .badge {
-  font-size: 0.72rem;
-  padding: 0.1rem 0.45rem;
-  border-radius: 999px;
-  background: var(--bg);
-  border: 1px solid var(--border);
+    font-size: 0.72rem;
+    padding: 0.1rem 0.45rem;
+    border-radius: 999px;
+    background: var(--bg);
+    border: 1px solid var(--border);
 }
 
-.ep-code { font-size: 0.78rem; }
-.lib { font-size: 0.78rem; }
-.season-label { font-weight: 500; }
+.ep-code {
+    font-size: 0.78rem;
+}
+.lib {
+    font-size: 0.78rem;
+}
+.season-label {
+    font-weight: 500;
+}
 
 button.primary {
-  background: var(--accent, #2563eb);
-  color: white;
-  border: 1px solid var(--accent, #2563eb);
-  border-radius: 4px;
-  cursor: pointer;
+    background: var(--accent, #2563eb);
+    color: white;
+    border: 1px solid var(--accent, #2563eb);
+    border-radius: 4px;
+    cursor: pointer;
 }
-button.primary:disabled { opacity: 0.5; cursor: not-allowed; }
+button.primary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
 
 .kind-tag {
-  font-size: 0.7rem;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  padding: 1px 6px;
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  font-weight: 600;
+    font-size: 0.7rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    padding: 1px 6px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-weight: 600;
 }
 </style>

--- a/frontend/src/components/SyncedView.vue
+++ b/frontend/src/components/SyncedView.vue
@@ -10,150 +10,223 @@ const error = ref("")
 const submitting = ref<Record<string, boolean>>({})
 
 async function load(): Promise<void> {
-  loading.value = true
-  error.value = ""
-  try {
-    const r = await api.synced()
-    items.value = r.items
-  } catch (e) {
-    error.value = (e as Error).message
-  } finally {
-    loading.value = false
-  }
+    loading.value = true
+    error.value = ""
+    try {
+        const r = await api.synced()
+        items.value = r.items
+    } catch (e) {
+        error.value = (e as Error).message
+    } finally {
+        loading.value = false
+    }
 }
 
 onMounted(load)
 
 async function syncNew(entry: SyncedEntry, n: number): Promise<void> {
-  if (!entry.lib) return
-  const eps = entry.new_unwatched.slice(0, n).map<[number, number]>(e => [e.season, e.episode])
-  submitting.value[entry.folder] = true
-  try {
-    const r = await api.sync({
-      lib: entry.lib,
-      folder: entry.folder,
-      selection_type: "episodes",
-      episodes: eps,
-    })
-    if (r.job_id) {
-      trackJob(r.job_id, { action: "Sync", name: entry.title, totalMediaFiles: r.total_media_files })
-      setTimeout(load, 1500)
+    if (!entry.lib) return
+    const eps = entry.new_unwatched
+        .slice(0, n)
+        .map<[number, number]>((e) => [e.season, e.episode])
+    submitting.value[entry.folder] = true
+    try {
+        const r = await api.sync({
+            lib: entry.lib,
+            folder: entry.folder,
+            selection_type: "episodes",
+            episodes: eps,
+        })
+        if (r.job_id) {
+            trackJob(r.job_id, {
+                action: "Sync",
+                name: entry.title,
+                totalMediaFiles: r.total_media_files,
+            })
+            setTimeout(load, 1500)
+        }
+    } finally {
+        submitting.value[entry.folder] = false
     }
-  } finally {
-    submitting.value[entry.folder] = false
-  }
 }
 
 function newBytes(entry: SyncedEntry, n: number): number {
-  return entry.new_unwatched.slice(0, n).reduce((s, e) => s + e.size_bytes, 0)
+    return entry.new_unwatched.slice(0, n).reduce((s, e) => s + e.size_bytes, 0)
 }
 </script>
 
 <template>
-  <div class="view fade-in">
-    <div v-if="loading" class="info">Loading synced library…</div>
-    <div v-else-if="error" class="info err">{{ error }}</div>
-    <template v-else>
-      <div v-if="items.length === 0" class="info">
-        <p>Nothing synced yet.</p>
-        <p class="dim">Pick a title in the Library tab to start.</p>
-      </div>
+    <div class="view fade-in">
+        <div v-if="loading" class="info">Loading synced library…</div>
+        <div v-else-if="error" class="info err">{{ error }}</div>
+        <template v-else>
+            <div v-if="items.length === 0" class="info">
+                <p>Nothing synced yet.</p>
+                <p class="dim">Pick a title in the Library tab to start.</p>
+            </div>
 
-      <div v-else class="list">
-        <div v-for="item in items" :key="item.folder" class="row">
-          <div class="thumb-wrap">
-            <img
-              v-if="item.lib"
-              :src="api.thumbUrl(item.lib, item.folder)"
-              :alt="item.title"
-              loading="lazy"
-              @error="($event.target as HTMLImageElement).style.display='none'"
-            />
-          </div>
-          <div class="meta-col" @click="item.lib && openDetail(item.lib, item.folder)">
-            <div class="title-line">
-              <span class="title">{{ item.title }}</span>
-              <span class="lib-tag dim">{{ item.lib }}</span>
+            <div v-else class="list">
+                <div v-for="item in items" :key="item.folder" class="row">
+                    <div class="thumb-wrap">
+                        <img
+                            v-if="item.lib"
+                            :src="api.thumbUrl(item.lib, item.folder)"
+                            :alt="item.title"
+                            loading="lazy"
+                            @error="
+                                (
+                                    $event.target as HTMLImageElement
+                                ).style.display = 'none'
+                            "
+                        />
+                    </div>
+                    <div
+                        class="meta-col"
+                        @click="item.lib && openDetail(item.lib, item.folder)"
+                    >
+                        <div class="title-line">
+                            <span class="title">{{ item.title }}</span>
+                            <span class="lib-tag dim">{{ item.lib }}</span>
+                        </div>
+                        <div class="size-line">
+                            <span>{{ humanSize(item.size_bytes) }}</span>
+                            <span
+                                v-if="item.new_unwatched.length > 0"
+                                class="new"
+                            >
+                                +{{ item.new_unwatched.length }} new
+                            </span>
+                        </div>
+                    </div>
+                    <div class="actions">
+                        <button
+                            v-if="item.new_unwatched.length > 0"
+                            class="primary"
+                            :disabled="submitting[item.folder]"
+                            @click="
+                                syncNew(
+                                    item,
+                                    Math.min(5, item.new_unwatched.length)
+                                )
+                            "
+                        >
+                            Sync next
+                            {{ Math.min(5, item.new_unwatched.length) }}
+                            <span class="dim small"
+                                >({{ humanSize(newBytes(item, 5)) }})</span
+                            >
+                        </button>
+                        <button
+                            v-if="item.new_unwatched.length > 5"
+                            :disabled="submitting[item.folder]"
+                            @click="syncNew(item, item.new_unwatched.length)"
+                        >
+                            Sync all {{ item.new_unwatched.length }}
+                        </button>
+                    </div>
+                </div>
             </div>
-            <div class="size-line">
-              <span>{{ humanSize(item.size_bytes) }}</span>
-              <span v-if="item.new_unwatched.length > 0" class="new">
-                +{{ item.new_unwatched.length }} new
-              </span>
-            </div>
-          </div>
-          <div class="actions">
-            <button
-              v-if="item.new_unwatched.length > 0"
-              class="primary"
-              :disabled="submitting[item.folder]"
-              @click="syncNew(item, Math.min(5, item.new_unwatched.length))"
-            >
-              Sync next {{ Math.min(5, item.new_unwatched.length) }}
-              <span class="dim small">({{ humanSize(newBytes(item, 5)) }})</span>
-            </button>
-            <button
-              v-if="item.new_unwatched.length > 5"
-              :disabled="submitting[item.folder]"
-              @click="syncNew(item, item.new_unwatched.length)"
-            >
-              Sync all {{ item.new_unwatched.length }}
-            </button>
-          </div>
-        </div>
-      </div>
-    </template>
-  </div>
+        </template>
+    </div>
 </template>
 
 <style scoped>
-.view { padding: 1rem; overflow-y: auto; flex: 1; }
-.info { padding: 3rem 1rem; text-align: center; color: var(--fg-muted); }
-.info.err { color: var(--danger); }
+.view {
+    padding: 1rem;
+    overflow-y: auto;
+    flex: 1;
+}
+.info {
+    padding: 3rem 1rem;
+    text-align: center;
+    color: var(--fg-muted);
+}
+.info.err {
+    color: var(--danger);
+}
 
-.list { display: flex; flex-direction: column; gap: 0.6rem; max-width: 900px; margin: 0 auto; }
+.list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    max-width: 900px;
+    margin: 0 auto;
+}
 .row {
-  display: flex;
-  gap: 0.8rem;
-  align-items: center;
-  background: var(--bg-elev);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 0.7rem;
+    display: flex;
+    gap: 0.8rem;
+    align-items: center;
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.7rem;
 }
 .thumb-wrap {
-  width: 50px;
-  aspect-ratio: 2 / 3;
-  background: var(--bg-elev-2);
-  border-radius: 4px;
-  overflow: hidden;
-  flex-shrink: 0;
+    width: 50px;
+    aspect-ratio: 2 / 3;
+    background: var(--bg-elev-2);
+    border-radius: 4px;
+    overflow: hidden;
+    flex-shrink: 0;
 }
-.thumb-wrap img { width: 100%; height: 100%; object-fit: cover; display: block; }
-.meta-col { flex: 1; min-width: 0; cursor: pointer; }
+.thumb-wrap img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+.meta-col {
+    flex: 1;
+    min-width: 0;
+    cursor: pointer;
+}
 .title-line {
-  display: flex; gap: 0.5rem; align-items: baseline;
-  overflow: hidden;
-  white-space: nowrap;
+    display: flex;
+    gap: 0.5rem;
+    align-items: baseline;
+    overflow: hidden;
+    white-space: nowrap;
 }
 .title {
-  font-weight: 500;
-  overflow: hidden; text-overflow: ellipsis;
+    font-weight: 500;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
-.lib-tag { font-size: 0.75rem; }
+.lib-tag {
+    font-size: 0.75rem;
+}
 .size-line {
-  display: flex; gap: 0.7rem; align-items: center; font-size: 0.83rem; color: var(--fg-muted);
+    display: flex;
+    gap: 0.7rem;
+    align-items: center;
+    font-size: 0.83rem;
+    color: var(--fg-muted);
 }
 .new {
-  color: var(--accent-progress);
-  font-weight: 600;
+    color: var(--accent-progress);
+    font-weight: 600;
 }
-.actions { display: flex; gap: 0.4rem; flex-wrap: wrap; justify-content: flex-end; }
-.actions .small { font-size: 0.75rem; font-weight: 400; margin-left: 4px; }
+.actions {
+    display: flex;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+}
+.actions .small {
+    font-size: 0.75rem;
+    font-weight: 400;
+    margin-left: 4px;
+}
 
 @media (max-width: 600px) {
-  .row { flex-wrap: wrap; }
-  .actions { flex: 1 1 100%; }
-  .actions button { flex: 1; }
+    .row {
+        flex-wrap: wrap;
+    }
+    .actions {
+        flex: 1 1 100%;
+    }
+    .actions button {
+        flex: 1;
+    }
 }
 </style>

--- a/frontend/src/components/SyncthingView.vue
+++ b/frontend/src/components/SyncthingView.vue
@@ -16,29 +16,29 @@ const error = ref("")
 let pollTimer: ReturnType<typeof setInterval> | null = null
 
 async function load(): Promise<void> {
-  error.value = ""
-  try {
-    const r = await api.syncthingOverview()
-    configured.value = r.configured
-    folders.value = r.folders
-  } catch (e) {
-    error.value = (e as Error).message
-  } finally {
-    loading.value = false
-  }
+    error.value = ""
+    try {
+        const r = await api.syncthingOverview()
+        configured.value = r.configured
+        folders.value = r.folders
+    } catch (e) {
+        error.value = (e as Error).message
+    } finally {
+        loading.value = false
+    }
 }
 
 function startPolling(): void {
-  if (pollTimer != null) return
-  load()
-  pollTimer = setInterval(load, POLL_INTERVAL_MS)
+    if (pollTimer != null) return
+    load()
+    pollTimer = setInterval(load, POLL_INTERVAL_MS)
 }
 
 function stopPolling(): void {
-  if (pollTimer != null) {
-    clearInterval(pollTimer)
-    pollTimer = null
-  }
+    if (pollTimer != null) {
+        clearInterval(pollTimer)
+        pollTimer = null
+    }
 }
 
 // onActivated handles tab returns under KeepAlive (App.vue wraps non-library
@@ -53,198 +53,224 @@ onUnmounted(stopPolling)
 </script>
 
 <template>
-  <div class="view fade-in">
-    <div v-if="!configured" class="info">
-      <p><strong>Syncthing not configured.</strong></p>
-      <p class="dim">
-        Set <code>SYNCTHING_URL</code> and <code>SYNCTHING_API_KEY</code> in
-        your <code>.env</code> file to enable this panel. See
-        <code>.env.example</code> for the template.
-      </p>
-    </div>
-    <div v-else-if="loading && folders.length === 0" class="info">
-      Loading Syncthing state…
-    </div>
-    <div v-else-if="error" class="info err">{{ error }}</div>
-    <template v-else>
-      <div v-if="folders.length === 0" class="info">
-        <p>Connected to Syncthing, but no folders are configured.</p>
-      </div>
-      <div v-else class="list">
-        <div
-          v-for="folder in folders"
-          :key="folder.folder_id"
-          class="folder"
-        >
-          <div class="folder-header">
-            <span class="folder-label">{{ folder.label }}</span>
-            <span class="folder-state" :class="`state-${folder.state}`">
-              {{ folder.state }}
-            </span>
-            <span class="folder-percent">{{ folder.percent }}%</span>
-          </div>
-          <div class="folder-bytes dim">
-            {{ humanSize(folder.in_sync_bytes) }} of
-            {{ humanSize(folder.global_bytes) }} in sync
-            <span v-if="folder.need_bytes > 0">
-              · {{ humanSize(folder.need_bytes) }} pending
-            </span>
-          </div>
-          <div class="bar">
-            <div class="bar-fill" :style="{ width: folder.percent + '%' }" />
-          </div>
-
-          <div v-if="folder.devices.length > 0" class="devices">
-            <div
-              v-for="dev in folder.devices"
-              :key="dev.device_id"
-              class="device"
-              :class="{
-                offline: !dev.connected && !dev.paused,
-                paused: dev.paused,
-                'in-sync': dev.connected && !dev.paused && dev.completion >= 100,
-              }"
-            >
-              <span class="device-name">{{ dev.name }}</span>
-              <span class="device-completion">{{ dev.completion }}%</span>
-              <span v-if="dev.paused" class="device-tag">paused</span>
-              <span v-else-if="!dev.connected" class="device-tag">offline</span>
-              <span v-else-if="dev.need_bytes > 0" class="device-tag">
-                {{ humanSize(dev.need_bytes) }} behind
-              </span>
-              <span v-else class="device-tag ok">in sync</span>
-            </div>
-          </div>
-          <div v-else class="info dim no-devices">
-            No remote devices share this folder.
-          </div>
+    <div class="view fade-in">
+        <div v-if="!configured" class="info">
+            <p><strong>Syncthing not configured.</strong></p>
+            <p class="dim">
+                Set <code>SYNCTHING_URL</code> and
+                <code>SYNCTHING_API_KEY</code> in your <code>.env</code> file to
+                enable this panel. See <code>.env.example</code> for the
+                template.
+            </p>
         </div>
-      </div>
-    </template>
-  </div>
+        <div v-else-if="loading && folders.length === 0" class="info">
+            Loading Syncthing state…
+        </div>
+        <div v-else-if="error" class="info err">{{ error }}</div>
+        <template v-else>
+            <div v-if="folders.length === 0" class="info">
+                <p>Connected to Syncthing, but no folders are configured.</p>
+            </div>
+            <div v-else class="list">
+                <div
+                    v-for="folder in folders"
+                    :key="folder.folder_id"
+                    class="folder"
+                >
+                    <div class="folder-header">
+                        <span class="folder-label">{{ folder.label }}</span>
+                        <span
+                            class="folder-state"
+                            :class="`state-${folder.state}`"
+                        >
+                            {{ folder.state }}
+                        </span>
+                        <span class="folder-percent"
+                            >{{ folder.percent }}%</span
+                        >
+                    </div>
+                    <div class="folder-bytes dim">
+                        {{ humanSize(folder.in_sync_bytes) }} of
+                        {{ humanSize(folder.global_bytes) }} in sync
+                        <span v-if="folder.need_bytes > 0">
+                            · {{ humanSize(folder.need_bytes) }} pending
+                        </span>
+                    </div>
+                    <div class="bar">
+                        <div
+                            class="bar-fill"
+                            :style="{ width: folder.percent + '%' }"
+                        />
+                    </div>
+
+                    <div v-if="folder.devices.length > 0" class="devices">
+                        <div
+                            v-for="dev in folder.devices"
+                            :key="dev.device_id"
+                            class="device"
+                            :class="{
+                                offline: !dev.connected && !dev.paused,
+                                paused: dev.paused,
+                                'in-sync':
+                                    dev.connected &&
+                                    !dev.paused &&
+                                    dev.completion >= 100,
+                            }"
+                        >
+                            <span class="device-name">{{ dev.name }}</span>
+                            <span class="device-completion"
+                                >{{ dev.completion }}%</span
+                            >
+                            <span v-if="dev.paused" class="device-tag"
+                                >paused</span
+                            >
+                            <span v-else-if="!dev.connected" class="device-tag"
+                                >offline</span
+                            >
+                            <span
+                                v-else-if="dev.need_bytes > 0"
+                                class="device-tag"
+                            >
+                                {{ humanSize(dev.need_bytes) }} behind
+                            </span>
+                            <span v-else class="device-tag ok">in sync</span>
+                        </div>
+                    </div>
+                    <div v-else class="info dim no-devices">
+                        No remote devices share this folder.
+                    </div>
+                </div>
+            </div>
+        </template>
+    </div>
 </template>
 
 <style scoped>
 .view {
-  padding: 1rem;
-  overflow-y: auto;
+    padding: 1rem;
+    overflow-y: auto;
 }
 .info {
-  padding: 1.5rem 1rem;
-  text-align: center;
-  color: var(--fg-muted);
+    padding: 1.5rem 1rem;
+    text-align: center;
+    color: var(--fg-muted);
 }
 .info.err {
-  color: var(--accent-danger, #b04040);
+    color: var(--accent-danger, #b04040);
 }
 .info code {
-  background: var(--bg-elev-2);
-  padding: 0.1em 0.4em;
-  border-radius: 3px;
-  font-size: 0.9em;
+    background: var(--bg-elev-2);
+    padding: 0.1em 0.4em;
+    border-radius: 3px;
+    font-size: 0.9em;
 }
 .dim {
-  color: var(--fg-muted);
+    color: var(--fg-muted);
 }
 
 .list {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
 }
 .folder {
-  background: var(--bg-elev-1);
-  border-radius: 8px;
-  padding: 1rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+    background: var(--bg-elev-1);
+    border-radius: 8px;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
 }
 .folder-header {
-  display: flex;
-  align-items: baseline;
-  gap: 0.75rem;
+    display: flex;
+    align-items: baseline;
+    gap: 0.75rem;
 }
 .folder-label {
-  font-weight: 600;
-  font-size: 1.05rem;
+    font-weight: 600;
+    font-size: 1.05rem;
 }
 .folder-state {
-  padding: 1px 8px;
-  border-radius: 10px;
-  background: var(--bg-elev-2);
-  color: var(--fg-muted);
-  font-size: 0.72rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
+    padding: 1px 8px;
+    border-radius: 10px;
+    background: var(--bg-elev-2);
+    color: var(--fg-muted);
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
 }
 .folder-state.state-syncing {
-  background: var(--accent-action, #4080c0);
-  color: #fff;
+    background: var(--accent-action, #4080c0);
+    color: #fff;
 }
 .folder-state.state-idle {
-  background: var(--bg-elev-2);
+    background: var(--bg-elev-2);
 }
 .folder-state.state-error,
 .folder-state.state-unknown {
-  background: var(--accent-danger, #b04040);
-  color: #fff;
+    background: var(--accent-danger, #b04040);
+    color: #fff;
 }
 .folder-percent {
-  margin-left: auto;
-  font-variant-numeric: tabular-nums;
-  font-weight: 600;
+    margin-left: auto;
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
 }
 
 .bar {
-  height: 6px;
-  background: var(--bg-elev-2);
-  border-radius: 3px;
-  overflow: hidden;
+    height: 6px;
+    background: var(--bg-elev-2);
+    border-radius: 3px;
+    overflow: hidden;
 }
 .bar-fill {
-  height: 100%;
-  background: var(--accent-action, #4080c0);
-  transition: width 0.4s ease;
+    height: 100%;
+    background: var(--accent-action, #4080c0);
+    transition: width 0.4s ease;
 }
 
 .devices {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  margin-top: 0.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    margin-top: 0.25rem;
 }
 .device {
-  display: flex;
-  align-items: baseline;
-  gap: 0.65rem;
-  padding: 0.35rem 0.6rem;
-  background: var(--bg-elev-2);
-  border-radius: 6px;
-  font-size: 0.92rem;
+    display: flex;
+    align-items: baseline;
+    gap: 0.65rem;
+    padding: 0.35rem 0.6rem;
+    background: var(--bg-elev-2);
+    border-radius: 6px;
+    font-size: 0.92rem;
 }
-.device.offline { opacity: 0.5; }
-.device.paused { opacity: 0.65; font-style: italic; }
+.device.offline {
+    opacity: 0.5;
+}
+.device.paused {
+    opacity: 0.65;
+    font-style: italic;
+}
 .device-name {
-  font-weight: 500;
-  min-width: 5rem;
+    font-weight: 500;
+    min-width: 5rem;
 }
 .device-completion {
-  font-variant-numeric: tabular-nums;
-  color: var(--fg-muted);
-  min-width: 3.5rem;
+    font-variant-numeric: tabular-nums;
+    color: var(--fg-muted);
+    min-width: 3.5rem;
 }
 .device-tag {
-  margin-left: auto;
-  font-size: 0.78rem;
-  color: var(--fg-muted);
+    margin-left: auto;
+    font-size: 0.78rem;
+    color: var(--fg-muted);
 }
 .device-tag.ok {
-  color: var(--accent-success, #4ca44c);
+    color: var(--accent-success, #4ca44c);
 }
 .no-devices {
-  font-size: 0.88rem;
-  padding: 0.5rem;
+    font-size: 0.88rem;
+    padding: 0.5rem;
 }
 </style>

--- a/frontend/src/components/TabBar.vue
+++ b/frontend/src/components/TabBar.vue
@@ -5,73 +5,85 @@ defineProps<{ tab: Tab; counts?: Partial<Record<Tab, number>> }>()
 defineEmits<{ (e: "change", t: Tab): void }>()
 
 const tabs: { id: Tab; label: string }[] = [
-  { id: "library",     label: "Library" },
-  { id: "synced",      label: "Synced" },
-  { id: "watchlist",   label: "Watchlist" },
-  { id: "maintenance", label: "Maintenance" },
-  { id: "syncthing",   label: "Syncthing" },
+    { id: "library", label: "Library" },
+    { id: "synced", label: "Synced" },
+    { id: "watchlist", label: "Watchlist" },
+    { id: "maintenance", label: "Maintenance" },
+    { id: "syncthing", label: "Syncthing" },
 ]
 </script>
 
 <template>
-  <nav class="tabs">
-    <button
-      v-for="t in tabs"
-      :key="t.id"
-      :class="['tab', { active: tab === t.id }]"
-      @click="$emit('change', t.id)"
-    >
-      {{ t.label }}
-      <span v-if="counts?.[t.id] != null" class="count">{{ counts[t.id] }}</span>
-    </button>
-  </nav>
+    <nav class="tabs">
+        <button
+            v-for="t in tabs"
+            :key="t.id"
+            :class="['tab', { active: tab === t.id }]"
+            @click="$emit('change', t.id)"
+        >
+            {{ t.label }}
+            <span v-if="counts?.[t.id] != null" class="count">{{
+                counts[t.id]
+            }}</span>
+        </button>
+    </nav>
 </template>
 
 <style scoped>
 .tabs {
-  display: flex;
-  gap: 2px;
-  padding: 0 1rem;
-  border-bottom: 1px solid var(--border);
-  background: var(--bg);
-  overflow-x: auto;
-  scrollbar-width: none;
+    display: flex;
+    gap: 2px;
+    padding: 0 1rem;
+    border-bottom: 1px solid var(--border);
+    background: var(--bg);
+    overflow-x: auto;
+    scrollbar-width: none;
 }
-.tabs::-webkit-scrollbar { display: none; }
+.tabs::-webkit-scrollbar {
+    display: none;
+}
 
 .tab {
-  padding: 0.65rem 0.95rem;
-  background: transparent;
-  border: none;
-  border-bottom: 2px solid transparent;
-  border-radius: 0;
-  color: var(--fg-muted);
-  font-weight: 500;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.45rem;
-  white-space: nowrap;
+    padding: 0.65rem 0.95rem;
+    background: transparent;
+    border: none;
+    border-bottom: 2px solid transparent;
+    border-radius: 0;
+    color: var(--fg-muted);
+    font-weight: 500;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    white-space: nowrap;
 }
-.tab:hover { color: var(--fg); background: transparent; }
+.tab:hover {
+    color: var(--fg);
+    background: transparent;
+}
 .tab.active {
-  color: var(--fg);
-  border-bottom-color: var(--accent-action);
+    color: var(--fg);
+    border-bottom-color: var(--accent-action);
 }
 .count {
-  background: var(--bg-elev-2);
-  color: var(--fg-muted);
-  padding: 1px 7px;
-  border-radius: 10px;
-  font-size: 0.72rem;
-  font-weight: 600;
+    background: var(--bg-elev-2);
+    color: var(--fg-muted);
+    padding: 1px 7px;
+    border-radius: 10px;
+    font-size: 0.72rem;
+    font-weight: 600;
 }
 .tab.active .count {
-  background: var(--accent-action);
-  color: #fff;
+    background: var(--accent-action);
+    color: #fff;
 }
 
 @media (max-width: 600px) {
-  .tabs { padding: 0 0.5rem; }
-  .tab { padding: 0.55rem 0.7rem; font-size: 0.92rem; }
+    .tabs {
+        padding: 0 0.5rem;
+    }
+    .tab {
+        padding: 0.55rem 0.7rem;
+        font-size: 0.92rem;
+    }
 }
 </style>

--- a/frontend/src/components/TitleCard.vue
+++ b/frontend/src/components/TitleCard.vue
@@ -12,156 +12,202 @@ const thumbUrl = api.thumbUrl(props.title.lib, props.title.folder)
 </script>
 
 <template>
-  <button class="card" @click="$emit('open', title.lib, title.folder)">
-    <div class="poster">
-      <img
-        v-if="!thumbErrored"
-        :src="thumbUrl"
-        :alt="title.name"
-        loading="lazy"
-        decoding="async"
-        @error="thumbErrored = true"
-      />
-      <div v-else class="poster-fallback">
-        <span>{{ title.name.slice(0, 2).toUpperCase() }}</span>
-      </div>
+    <button class="card" @click="$emit('open', title.lib, title.folder)">
+        <div class="poster">
+            <img
+                v-if="!thumbErrored"
+                :src="thumbUrl"
+                :alt="title.name"
+                loading="lazy"
+                decoding="async"
+                @error="thumbErrored = true"
+            />
+            <div v-else class="poster-fallback">
+                <span>{{ title.name.slice(0, 2).toUpperCase() }}</span>
+            </div>
 
-      <div class="lib-badge">{{ libraryShort(title.lib) }}</div>
+            <div class="lib-badge">{{ libraryShort(title.lib) }}</div>
 
-      <div class="badges">
-        <div v-if="title.synced_pct > 0" class="badge sync" :title="`Synced ${title.synced_pct}%`">
-          <svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor"><path d="M12 16l-6-6h12z"/></svg>
-          <span v-if="title.kind !== 'movie'">{{ title.synced_pct }}%</span>
+            <div class="badges">
+                <div
+                    v-if="title.synced_pct > 0"
+                    class="badge sync"
+                    :title="`Synced ${title.synced_pct}%`"
+                >
+                    <svg
+                        width="11"
+                        height="11"
+                        viewBox="0 0 24 24"
+                        fill="currentColor"
+                    >
+                        <path d="M12 16l-6-6h12z" />
+                    </svg>
+                    <span v-if="title.kind !== 'movie'"
+                        >{{ title.synced_pct }}%</span
+                    >
+                </div>
+                <div
+                    v-if="title.watched_pct >= 100"
+                    class="badge watched"
+                    title="Watched"
+                >
+                    <svg
+                        width="11"
+                        height="11"
+                        viewBox="0 0 24 24"
+                        fill="currentColor"
+                    >
+                        <path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4z" />
+                    </svg>
+                </div>
+                <div
+                    v-else-if="title.watched_pct > 0"
+                    class="badge watching"
+                    :title="`Watching · ${title.watched_pct}%`"
+                >
+                    {{ title.watched_pct }}%
+                </div>
+            </div>
+
+            <div class="gradient"></div>
         </div>
-        <div v-if="title.watched_pct >= 100" class="badge watched" title="Watched">
-          <svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor"><path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4z"/></svg>
-        </div>
-        <div
-          v-else-if="title.watched_pct > 0"
-          class="badge watching"
-          :title="`Watching · ${title.watched_pct}%`"
-        >
-          {{ title.watched_pct }}%
-        </div>
-      </div>
 
-      <div class="gradient"></div>
-    </div>
-
-    <div class="info">
-      <div class="name" :title="title.name">{{ title.name }}</div>
-      <div class="meta">
-        <span v-if="title.year">{{ title.year }}</span>
-        <span v-if="title.ep_count" class="dim">{{ title.ep_count }} ep</span>
-      </div>
-    </div>
-  </button>
+        <div class="info">
+            <div class="name" :title="title.name">{{ title.name }}</div>
+            <div class="meta">
+                <span v-if="title.year">{{ title.year }}</span>
+                <span v-if="title.ep_count" class="dim"
+                    >{{ title.ep_count }} ep</span
+                >
+            </div>
+        </div>
+    </button>
 </template>
 
 <style scoped>
 .card {
-  text-align: left;
-  background: transparent;
-  border: none;
-  padding: 0;
-  border-radius: var(--radius);
-  cursor: pointer;
-  transition: transform 140ms ease, box-shadow 140ms ease;
+    text-align: left;
+    background: transparent;
+    border: none;
+    padding: 0;
+    border-radius: var(--radius);
+    cursor: pointer;
+    transition:
+        transform 140ms ease,
+        box-shadow 140ms ease;
 }
-.card:hover { transform: translateY(-3px); }
-.card:hover .poster { box-shadow: 0 8px 24px rgba(0,0,0,0.4); }
+.card:hover {
+    transform: translateY(-3px);
+}
+.card:hover .poster {
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
 
 .poster {
-  position: relative;
-  width: 100%;
-  aspect-ratio: 2 / 3;
-  background: var(--bg-elev);
-  border-radius: var(--radius);
-  overflow: hidden;
-  border: 1px solid var(--border);
-  transition: box-shadow 140ms ease, border-color 140ms ease;
+    position: relative;
+    width: 100%;
+    aspect-ratio: 2 / 3;
+    background: var(--bg-elev);
+    border-radius: var(--radius);
+    overflow: hidden;
+    border: 1px solid var(--border);
+    transition:
+        box-shadow 140ms ease,
+        border-color 140ms ease;
 }
 .poster img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  display: block;
-  background: var(--bg-elev);
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+    background: var(--bg-elev);
 }
 .poster-fallback {
-  width: 100%; height: 100%;
-  display: flex; align-items: center; justify-content: center;
-  background: linear-gradient(135deg, #1a2030, #2a3349);
-  color: var(--fg-dim);
-  font-size: 2rem;
-  font-weight: 700;
-  letter-spacing: 0.02em;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, #1a2030, #2a3349);
+    color: var(--fg-dim);
+    font-size: 2rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
 }
 
 .lib-badge {
-  position: absolute;
-  top: 6px; left: 6px;
-  padding: 2px 6px;
-  background: rgba(0,0,0,0.6);
-  color: var(--fg);
-  font-size: 0.65rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  border-radius: 4px;
-  backdrop-filter: blur(8px);
+    position: absolute;
+    top: 6px;
+    left: 6px;
+    padding: 2px 6px;
+    background: rgba(0, 0, 0, 0.6);
+    color: var(--fg);
+    font-size: 0.65rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    border-radius: 4px;
+    backdrop-filter: blur(8px);
 }
 
 .badges {
-  position: absolute;
-  top: 6px; right: 6px;
-  display: flex; gap: 4px;
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    display: flex;
+    gap: 4px;
 }
 .badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 3px;
-  background: rgba(0,0,0,0.7);
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 0.7rem;
-  font-weight: 700;
-  backdrop-filter: blur(8px);
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    background: rgba(0, 0, 0, 0.7);
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 0.7rem;
+    font-weight: 700;
+    backdrop-filter: blur(8px);
 }
-.badge.sync { color: var(--accent-sync); }
-.badge.watched { color: var(--accent-watched); }
-.badge.watching { color: var(--accent-progress); }
+.badge.sync {
+    color: var(--accent-sync);
+}
+.badge.watched {
+    color: var(--accent-watched);
+}
+.badge.watching {
+    color: var(--accent-progress);
+}
 
 .gradient {
-  position: absolute;
-  inset: auto 0 0 0;
-  height: 50%;
-  background: linear-gradient(to bottom, transparent, rgba(0,0,0,0.75));
-  pointer-events: none;
+    position: absolute;
+    inset: auto 0 0 0;
+    height: 50%;
+    background: linear-gradient(to bottom, transparent, rgba(0, 0, 0, 0.75));
+    pointer-events: none;
 }
 
 .info {
-  padding: 8px 4px 4px;
+    padding: 8px 4px 4px;
 }
 .name {
-  font-size: 0.92rem;
-  font-weight: 500;
-  line-height: 1.25;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  margin-bottom: 2px;
-  /* Reserve two lines of space even for single-line names so the .info
+    font-size: 0.92rem;
+    font-weight: 500;
+    line-height: 1.25;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    margin-bottom: 2px;
+    /* Reserve two lines of space even for single-line names so the .info
      section has a constant height. Without this, a one-line name shrinks
      the card and the grid row's align-items: stretch behavior pushes
      short-name posters down a few pixels relative to two-line neighbours. */
-  min-height: calc(2 * 1.25em);
+    min-height: calc(2 * 1.25em);
 }
 .meta {
-  font-size: 0.75rem;
-  color: var(--fg-muted);
-  display: flex;
-  gap: 0.5rem;
+    font-size: 0.75rem;
+    color: var(--fg-muted);
+    display: flex;
+    gap: 0.5rem;
 }
 </style>

--- a/frontend/src/components/TitleGrid.vue
+++ b/frontend/src/components/TitleGrid.vue
@@ -10,74 +10,90 @@ const visible = ref(PAGE)
 const list = computed(() => filteredTitles.value.slice(0, visible.value))
 const total = computed(() => filteredTitles.value.length)
 
-watch(filteredTitles, () => { visible.value = PAGE })
+watch(filteredTitles, () => {
+    visible.value = PAGE
+})
 
 function onScroll(e: Event): void {
-  const el = e.target as HTMLElement
-  if (el.scrollTop + el.clientHeight > el.scrollHeight - 400) {
-    if (visible.value < total.value) {
-      visible.value = Math.min(visible.value + PAGE, total.value)
+    const el = e.target as HTMLElement
+    if (el.scrollTop + el.clientHeight > el.scrollHeight - 400) {
+        if (visible.value < total.value) {
+            visible.value = Math.min(visible.value + PAGE, total.value)
+        }
     }
-  }
 }
 </script>
 
 <template>
-  <div class="grid-scroll" @scroll.passive="onScroll">
-    <div class="grid" :class="{ empty: total === 0 }">
-      <TitleCard
-        v-for="t in list"
-        :key="t.id"
-        :title="t"
-        @open="openDetail"
-      />
-    </div>
+    <div class="grid-scroll" @scroll.passive="onScroll">
+        <div class="grid" :class="{ empty: total === 0 }">
+            <TitleCard
+                v-for="t in list"
+                :key="t.id"
+                :title="t"
+                @open="openDetail"
+            />
+        </div>
 
-    <div v-if="total === 0" class="empty-state">
-      <p>No titles match.</p>
-      <p class="dim">Try fewer keywords, or clear the filters.</p>
-    </div>
+        <div v-if="total === 0" class="empty-state">
+            <p>No titles match.</p>
+            <p class="dim">Try fewer keywords, or clear the filters.</p>
+        </div>
 
-    <div v-else-if="visible < total" class="more-hint dim">
-      Showing {{ visible }} of {{ total }} — scroll for more
+        <div v-else-if="visible < total" class="more-hint dim">
+            Showing {{ visible }} of {{ total }} — scroll for more
+        </div>
     </div>
-  </div>
 </template>
 
 <style scoped>
 .grid-scroll {
-  flex: 1;
-  overflow-y: auto;
-  padding: 1rem;
+    flex: 1;
+    overflow-y: auto;
+    padding: 1rem;
 }
 .grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
-  gap: 1rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    gap: 1rem;
 }
-.grid.empty { min-height: 30vh; }
+.grid.empty {
+    min-height: 30vh;
+}
 
 .empty-state {
-  text-align: center;
-  padding: 4rem 1rem;
-  color: var(--fg-muted);
+    text-align: center;
+    padding: 4rem 1rem;
+    color: var(--fg-muted);
 }
-.empty-state p { margin: 0.25rem 0; }
+.empty-state p {
+    margin: 0.25rem 0;
+}
 
 .more-hint {
-  text-align: center;
-  padding: 2rem 1rem;
-  font-size: 0.85rem;
+    text-align: center;
+    padding: 2rem 1rem;
+    font-size: 0.85rem;
 }
 
 @media (min-width: 900px) {
-  .grid { grid-template-columns: repeat(auto-fill, minmax(160px, 1fr)); gap: 1.1rem; }
+    .grid {
+        grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+        gap: 1.1rem;
+    }
 }
 @media (min-width: 1400px) {
-  .grid { grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); }
+    .grid {
+        grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    }
 }
 @media (max-width: 480px) {
-  .grid-scroll { padding: 0.6rem; }
-  .grid { grid-template-columns: repeat(2, 1fr); gap: 0.65rem; }
+    .grid-scroll {
+        padding: 0.6rem;
+    }
+    .grid {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 0.65rem;
+    }
 }
 </style>

--- a/frontend/src/components/TopBar.vue
+++ b/frontend/src/components/TopBar.vue
@@ -11,116 +11,169 @@ const syncedCount = computed(() => store.disk?.synced_titles ?? 0)
 </script>
 
 <template>
-  <header class="topbar">
-    <div class="brand">
-      <span class="dot"></span>
-      <span class="name">synclet</span>
-    </div>
+    <header class="topbar">
+        <div class="brand">
+            <span class="dot"></span>
+            <span class="name">synclet</span>
+        </div>
 
-    <div class="disk" v-if="store.disk">
-      <div class="disk-label">
-        <span class="dim">synced</span>
-        <strong>{{ syncedBytes }}</strong>
-        <span class="dim">·</span>
-        <span class="dim">{{ syncedCount }} item{{ syncedCount === 1 ? "" : "s" }}</span>
-        <span class="sep">/</span>
-        <span class="dim">{{ freeBytes }} free</span>
-      </div>
-      <div class="bar"><div class="fill" :style="{ width: diskPct + '%' }"></div></div>
-    </div>
+        <div v-if="store.disk" class="disk">
+            <div class="disk-label">
+                <span class="dim">synced</span>
+                <strong>{{ syncedBytes }}</strong>
+                <span class="dim">·</span>
+                <span class="dim"
+                    >{{ syncedCount }} item{{
+                        syncedCount === 1 ? "" : "s"
+                    }}</span
+                >
+                <span class="sep">/</span>
+                <span class="dim">{{ freeBytes }} free</span>
+            </div>
+            <div class="bar">
+                <div class="fill" :style="{ width: diskPct + '%' }"></div>
+            </div>
+        </div>
 
-    <div class="actions">
-      <button class="ghost" title="Paste a Plex link or search query" @click="onPasteLink">
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71" />
-          <path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71" />
-        </svg>
-        <span class="lbl">paste</span>
-      </button>
-      <button class="ghost" title="Rescan library" @click="onRefresh">
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M23 4v6h-6" />
-          <path d="M20.49 15A9 9 0 116.51 5.36L1 10" />
-        </svg>
-      </button>
-    </div>
-  </header>
+        <div class="actions">
+            <button
+                class="ghost"
+                title="Paste a Plex link or search query"
+                @click="onPasteLink"
+            >
+                <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                >
+                    <path
+                        d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"
+                    />
+                    <path
+                        d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"
+                    />
+                </svg>
+                <span class="lbl">paste</span>
+            </button>
+            <button class="ghost" title="Rescan library" @click="onRefresh">
+                <svg
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                >
+                    <path d="M23 4v6h-6" />
+                    <path d="M20.49 15A9 9 0 116.51 5.36L1 10" />
+                </svg>
+            </button>
+        </div>
+    </header>
 </template>
 
 <style scoped>
 .topbar {
-  position: sticky;
-  top: 0;
-  z-index: 50;
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  padding: 0.65rem 1rem;
-  background: rgba(12, 14, 18, 0.92);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
-  border-bottom: 1px solid var(--border);
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.65rem 1rem;
+    background: rgba(12, 14, 18, 0.92);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--border);
 }
 .brand {
-  display: flex;
-  align-items: center;
-  gap: 0.45rem;
-  font-weight: 700;
-  letter-spacing: -0.01em;
-  font-size: 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    font-size: 1rem;
 }
-.brand .name { color: var(--fg); }
+.brand .name {
+    color: var(--fg);
+}
 .dot {
-  width: 9px; height: 9px;
-  border-radius: 50%;
-  background: var(--accent-sync);
-  box-shadow: 0 0 12px rgba(41, 208, 208, 0.55);
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    background: var(--accent-sync);
+    box-shadow: 0 0 12px rgba(41, 208, 208, 0.55);
 }
 .disk {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  min-width: 0;
-  max-width: 460px;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+    max-width: 460px;
 }
 .disk-label {
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-  font-size: 0.82rem;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-size: 0.82rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
-.disk-label strong { color: var(--accent-sync); }
-.sep { color: var(--fg-dim); margin: 0 0.25rem; }
+.disk-label strong {
+    color: var(--accent-sync);
+}
+.sep {
+    color: var(--fg-dim);
+    margin: 0 0.25rem;
+}
 .bar {
-  height: 4px;
-  background: var(--bg-elev);
-  border-radius: 4px;
-  overflow: hidden;
+    height: 4px;
+    background: var(--bg-elev);
+    border-radius: 4px;
+    overflow: hidden;
 }
 .fill {
-  height: 100%;
-  background: linear-gradient(90deg, var(--accent-action), var(--accent-sync));
-  transition: width 220ms ease;
+    height: 100%;
+    background: linear-gradient(
+        90deg,
+        var(--accent-action),
+        var(--accent-sync)
+    );
+    transition: width 220ms ease;
 }
 .actions {
-  display: flex;
-  gap: 0.4rem;
+    display: flex;
+    gap: 0.4rem;
 }
 .actions button {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.45rem 0.7rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.45rem 0.7rem;
 }
-.actions .lbl { font-size: 0.85rem; }
+.actions .lbl {
+    font-size: 0.85rem;
+}
 
 @media (max-width: 600px) {
-  .topbar { padding: 0.55rem 0.7rem; gap: 0.6rem; }
-  .disk { display: none; }
-  .actions .lbl { display: none; }
+    .topbar {
+        padding: 0.55rem 0.7rem;
+        gap: 0.6rem;
+    }
+    .disk {
+        display: none;
+    }
+    .actions .lbl {
+        display: none;
+    }
 }
 </style>

--- a/frontend/src/components/WatchlistView.vue
+++ b/frontend/src/components/WatchlistView.vue
@@ -9,109 +9,188 @@ const loading = ref(true)
 const error = ref("")
 
 async function load(): Promise<void> {
-  loading.value = true
-  error.value = ""
-  try {
-    const r = await api.watchlist()
-    items.value = r.items
-  } catch (e) {
-    error.value = (e as Error).message
-  } finally {
-    loading.value = false
-  }
+    loading.value = true
+    error.value = ""
+    try {
+        const r = await api.watchlist()
+        items.value = r.items
+    } catch (e) {
+        error.value = (e as Error).message
+    } finally {
+        loading.value = false
+    }
 }
 
 onMounted(load)
 </script>
 
 <template>
-  <div class="view fade-in">
-    <div v-if="loading" class="info">Fetching watchlist…</div>
-    <div v-else-if="error" class="info err">{{ error }}</div>
-    <template v-else>
-      <div v-if="items.length === 0" class="info">
-        <p>Watchlist is empty.</p>
-      </div>
-
-      <div v-else class="list">
-        <div
-          v-for="item in items"
-          :key="item.guid || item.title"
-          class="row"
-          :class="{ unavail: !item.matched }"
-          @click="item.matched && item.lib && item.folder && openDetail(item.lib, item.folder)"
-        >
-          <div class="thumb-wrap">
-            <img
-              v-if="item.matched && item.lib && item.folder"
-              :src="api.thumbUrl(item.lib, item.folder)"
-              :alt="item.title"
-              loading="lazy"
-              @error="($event.target as HTMLImageElement).style.display='none'"
-            />
-          </div>
-          <div class="meta-col">
-            <div class="title">{{ item.title }}</div>
-            <div class="meta dim">
-              <span v-if="item.category">{{ item.category }}</span>
-              <span v-if="item.matched && item.lib">
-                <span v-if="item.category"> · </span>
-                {{ item.lib }}
-              </span>
-              <span v-else class="unavail-tag">not in library</span>
+    <div class="view fade-in">
+        <div v-if="loading" class="info">Fetching watchlist…</div>
+        <div v-else-if="error" class="info err">{{ error }}</div>
+        <template v-else>
+            <div v-if="items.length === 0" class="info">
+                <p>Watchlist is empty.</p>
             </div>
-          </div>
-          <div v-if="item.matched" class="status">
-            <span v-if="(item.synced_pct ?? 0) > 0" class="dot synced" title="Synced">⬇</span>
-            <span v-if="(item.watched_pct ?? 0) >= 100" class="dot watched" title="Watched">●</span>
-            <span v-else-if="(item.watched_pct ?? 0) > 0" class="dot prog">{{ item.watched_pct }}%</span>
-          </div>
-        </div>
-      </div>
-    </template>
-  </div>
+
+            <div v-else class="list">
+                <div
+                    v-for="item in items"
+                    :key="item.guid || item.title"
+                    class="row"
+                    :class="{ unavail: !item.matched }"
+                    @click="
+                        item.matched &&
+                        item.lib &&
+                        item.folder &&
+                        openDetail(item.lib, item.folder)
+                    "
+                >
+                    <div class="thumb-wrap">
+                        <img
+                            v-if="item.matched && item.lib && item.folder"
+                            :src="api.thumbUrl(item.lib, item.folder)"
+                            :alt="item.title"
+                            loading="lazy"
+                            @error="
+                                (
+                                    $event.target as HTMLImageElement
+                                ).style.display = 'none'
+                            "
+                        />
+                    </div>
+                    <div class="meta-col">
+                        <div class="title">{{ item.title }}</div>
+                        <div class="meta dim">
+                            <span v-if="item.category">{{
+                                item.category
+                            }}</span>
+                            <span v-if="item.matched && item.lib">
+                                <span v-if="item.category"> · </span>
+                                {{ item.lib }}
+                            </span>
+                            <span v-else class="unavail-tag"
+                                >not in library</span
+                            >
+                        </div>
+                    </div>
+                    <div v-if="item.matched" class="status">
+                        <span
+                            v-if="(item.synced_pct ?? 0) > 0"
+                            class="dot synced"
+                            title="Synced"
+                            >⬇</span
+                        >
+                        <span
+                            v-if="(item.watched_pct ?? 0) >= 100"
+                            class="dot watched"
+                            title="Watched"
+                            >●</span
+                        >
+                        <span
+                            v-else-if="(item.watched_pct ?? 0) > 0"
+                            class="dot prog"
+                            >{{ item.watched_pct }}%</span
+                        >
+                    </div>
+                </div>
+            </div>
+        </template>
+    </div>
 </template>
 
 <style scoped>
-.view { padding: 1rem; overflow-y: auto; flex: 1; }
-.info { padding: 3rem 1rem; text-align: center; color: var(--fg-muted); }
-.info.err { color: var(--danger); }
-
-.list { display: flex; flex-direction: column; gap: 0.5rem; max-width: 900px; margin: 0 auto; }
-.row {
-  display: flex;
-  gap: 0.8rem;
-  align-items: center;
-  background: var(--bg-elev);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 0.6rem 0.7rem;
-  cursor: pointer;
-  transition: background 100ms ease;
+.view {
+    padding: 1rem;
+    overflow-y: auto;
+    flex: 1;
 }
-.row:hover { background: var(--bg-hover); }
-.row.unavail { opacity: 0.55; cursor: default; }
-.row.unavail:hover { background: var(--bg-elev); }
+.info {
+    padding: 3rem 1rem;
+    text-align: center;
+    color: var(--fg-muted);
+}
+.info.err {
+    color: var(--danger);
+}
+
+.list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    max-width: 900px;
+    margin: 0 auto;
+}
+.row {
+    display: flex;
+    gap: 0.8rem;
+    align-items: center;
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.6rem 0.7rem;
+    cursor: pointer;
+    transition: background 100ms ease;
+}
+.row:hover {
+    background: var(--bg-hover);
+}
+.row.unavail {
+    opacity: 0.55;
+    cursor: default;
+}
+.row.unavail:hover {
+    background: var(--bg-elev);
+}
 
 .thumb-wrap {
-  width: 42px;
-  aspect-ratio: 2 / 3;
-  background: var(--bg-elev-2);
-  border-radius: 4px;
-  overflow: hidden;
-  flex-shrink: 0;
+    width: 42px;
+    aspect-ratio: 2 / 3;
+    background: var(--bg-elev-2);
+    border-radius: 4px;
+    overflow: hidden;
+    flex-shrink: 0;
 }
-.thumb-wrap img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.thumb-wrap img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
 
-.meta-col { flex: 1; min-width: 0; }
-.title { font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.meta { font-size: 0.78rem; }
-.unavail-tag { color: var(--fg-dim); font-style: italic; }
+.meta-col {
+    flex: 1;
+    min-width: 0;
+}
+.title {
+    font-weight: 500;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.meta {
+    font-size: 0.78rem;
+}
+.unavail-tag {
+    color: var(--fg-dim);
+    font-style: italic;
+}
 
 .status {
-  display: flex; gap: 0.5rem; align-items: center; font-size: 0.95rem;
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    font-size: 0.95rem;
 }
-.dot.synced { color: var(--accent-sync); }
-.dot.watched { color: var(--accent-watched); }
-.dot.prog { color: var(--accent-progress); font-size: 0.78rem; font-weight: 600; }
+.dot.synced {
+    color: var(--accent-sync);
+}
+.dot.watched {
+    color: var(--accent-watched);
+}
+.dot.prog {
+    color: var(--accent-progress);
+    font-size: 0.78rem;
+    font-weight: 600;
+}
 </style>

--- a/frontend/src/fuzzy.test.ts
+++ b/frontend/src/fuzzy.test.ts
@@ -7,48 +7,50 @@ import { describe, expect, it } from "vitest"
 import { fuzzyScore } from "./fuzzy"
 
 describe("fuzzyScore", () => {
-  it("exact match scores 2", () => {
-    expect(fuzzyScore("Fallout", "Fallout")).toBe(2)
-  })
+    it("exact match scores 2", () => {
+        expect(fuzzyScore("Fallout", "Fallout")).toBe(2)
+    })
 
-  it("case-insensitive exact match", () => {
-    expect(fuzzyScore("fallout", "FALLOUT")).toBe(2)
-  })
+    it("case-insensitive exact match", () => {
+        expect(fuzzyScore("fallout", "FALLOUT")).toBe(2)
+    })
 
-  it("substring scores between 1 and 2", () => {
-    const s = fuzzyScore("fa", "Fallout")
-    expect(s).toBeGreaterThan(1)
-    expect(s).toBeLessThan(2)
-  })
+    it("substring scores between 1 and 2", () => {
+        const s = fuzzyScore("fa", "Fallout")
+        expect(s).toBeGreaterThan(1)
+        expect(s).toBeLessThan(2)
+    })
 
-  it("shorter target boosts substring score", () => {
-    expect(fuzzyScore("fall", "Fall")).toBeGreaterThan(fuzzyScore("fall", "Fallout"))
-  })
+    it("shorter target boosts substring score", () => {
+        expect(fuzzyScore("fall", "Fall")).toBeGreaterThan(
+            fuzzyScore("fall", "Fallout")
+        )
+    })
 
-  it("all-words substring scores 0.9", () => {
-    expect(fuzzyScore("call saul better", "Better Call Saul")).toBe(0.9)
-  })
+    it("all-words substring scores 0.9", () => {
+        expect(fuzzyScore("call saul better", "Better Call Saul")).toBe(0.9)
+    })
 
-  it("prefix-only match scores in 0.5–0.85 range", () => {
-    // "bet" prefixes "Better"; not a substring of the whole target
-    const s = fuzzyScore("bet", "Better Call Saul")
-    // "bet" IS in "Better Call Saul" as substring → 1+ score, not prefix-only
-    expect(s).toBeGreaterThan(1)
-  })
+    it("prefix-only match scores in 0.5–0.85 range", () => {
+        // "bet" prefixes "Better"; not a substring of the whole target
+        const s = fuzzyScore("bet", "Better Call Saul")
+        // "bet" IS in "Better Call Saul" as substring → 1+ score, not prefix-only
+        expect(s).toBeGreaterThan(1)
+    })
 
-  it("empty query scores 0", () => {
-    expect(fuzzyScore("", "Fallout")).toBe(0)
-  })
+    it("empty query scores 0", () => {
+        expect(fuzzyScore("", "Fallout")).toBe(0)
+    })
 
-  it("ranking is monotonic", () => {
-    const target = "Better Call Saul"
-    const scores = [
-      fuzzyScore("better call saul", target),
-      fuzzyScore("better call", target),
-      fuzzyScore("call", target),
-      fuzzyScore("xyz", target),
-    ]
-    const sorted = [...scores].sort((a, b) => b - a)
-    expect(scores).toEqual(sorted)
-  })
+    it("ranking is monotonic", () => {
+        const target = "Better Call Saul"
+        const scores = [
+            fuzzyScore("better call saul", target),
+            fuzzyScore("better call", target),
+            fuzzyScore("call", target),
+            fuzzyScore("xyz", target),
+        ]
+        const sorted = [...scores].sort((a, b) => b - a)
+        expect(scores).toEqual(sorted)
+    })
 })

--- a/frontend/src/fuzzy.ts
+++ b/frontend/src/fuzzy.ts
@@ -6,22 +6,22 @@
  * matching change goes in the Python file, and vice versa.
  */
 export function fuzzyScore(query: string, target: string): number {
-  if (!query) return 0
-  const q = query.toLowerCase()
-  const t = target.toLowerCase()
-  if (q === t) return 2
-  if (t.includes(q)) return 1 + q.length / Math.max(t.length, 1)
-  const words = q.split(/\s+/).filter(Boolean)
-  if (words.length && words.every(w => t.includes(w))) return 0.9
-  const tWords = t.split(/\s+/)
-  let prefix = 0
-  for (const w of words) {
-    if (tWords.some(tw => tw.startsWith(w))) prefix++
-  }
-  if (prefix > 0) return 0.5 + (prefix / words.length) * 0.35
-  // SequenceMatcher-style ratio — not portable from Python, but the fallback
-  // tier just needs to be small enough to fall below resolve.py's _FUZZY_MIN_SCORE.
-  // For the frontend we use the same threshold (0.1) the existing filter
-  // applied, so this approximation is fine.
-  return 0
+    if (!query) return 0
+    const q = query.toLowerCase()
+    const t = target.toLowerCase()
+    if (q === t) return 2
+    if (t.includes(q)) return 1 + q.length / Math.max(t.length, 1)
+    const words = q.split(/\s+/).filter(Boolean)
+    if (words.length && words.every((w) => t.includes(w))) return 0.9
+    const tWords = t.split(/\s+/)
+    let prefix = 0
+    for (const w of words) {
+        if (tWords.some((tw) => tw.startsWith(w))) prefix++
+    }
+    if (prefix > 0) return 0.5 + (prefix / words.length) * 0.35
+    // SequenceMatcher-style ratio — not portable from Python, but the fallback
+    // tier just needs to be small enough to fall below resolve.py's _FUZZY_MIN_SCORE.
+    // For the frontend we use the same threshold (0.1) the existing filter
+    // applied, so this approximation is fine.
+    return 0
 }

--- a/frontend/src/store.test.ts
+++ b/frontend/src/store.test.ts
@@ -13,69 +13,89 @@ import { humanSize, epCode, libraryShort, libraryLabel } from "./store"
 // poke at the implementation via an exported re-export. Add export when needed.
 
 describe("humanSize", () => {
-  it("formats bytes under 1 KB", () => {
-    expect(humanSize(0)).toBe("0 B")
-    expect(humanSize(512)).toBe("512 B")
-  })
+    it("formats bytes under 1 KB", () => {
+        expect(humanSize(0)).toBe("0 B")
+        expect(humanSize(512)).toBe("512 B")
+    })
 
-  it("formats kilobytes", () => {
-    expect(humanSize(1024)).toBe("1.0 KB")
-    expect(humanSize(2048)).toBe("2.0 KB")
-  })
+    it("formats kilobytes", () => {
+        expect(humanSize(1024)).toBe("1.0 KB")
+        expect(humanSize(2048)).toBe("2.0 KB")
+    })
 
-  it("formats megabytes", () => {
-    expect(humanSize(1024 * 1024)).toBe("1.0 MB")
-    expect(humanSize(5 * 1024 * 1024)).toBe("5.0 MB")
-  })
+    it("formats megabytes", () => {
+        expect(humanSize(1024 * 1024)).toBe("1.0 MB")
+        expect(humanSize(5 * 1024 * 1024)).toBe("5.0 MB")
+    })
 
-  it("formats gigabytes", () => {
-    expect(humanSize(1024 ** 3)).toBe("1.0 GB")
-  })
+    it("formats gigabytes", () => {
+        expect(humanSize(1024 ** 3)).toBe("1.0 GB")
+    })
 
-  it("uses integer formatting for large values within a unit", () => {
-    expect(humanSize(50 * 1024)).toBe("50 KB")
-  })
+    it("uses integer formatting for large values within a unit", () => {
+        expect(humanSize(50 * 1024)).toBe("50 KB")
+    })
 
-  it("scales up to terabytes and beyond", () => {
-    expect(humanSize(1024 ** 4)).toBe("1.0 TB")
-  })
+    it("scales up to terabytes and beyond", () => {
+        expect(humanSize(1024 ** 4)).toBe("1.0 TB")
+    })
 })
 
 describe("epCode", () => {
-  it("pads single-digit numbers", () => {
-    expect(epCode(1, 1)).toBe("S01E01")
-    expect(epCode(2, 9)).toBe("S02E09")
-  })
+    it("pads single-digit numbers", () => {
+        expect(epCode(1, 1)).toBe("S01E01")
+        expect(epCode(2, 9)).toBe("S02E09")
+    })
 
-  it("does not truncate two-digit numbers", () => {
-    expect(epCode(12, 34)).toBe("S12E34")
-  })
+    it("does not truncate two-digit numbers", () => {
+        expect(epCode(12, 34)).toBe("S12E34")
+    })
 
-  it("handles zero", () => {
-    // Specials are S00 — must not lose the digit
-    expect(epCode(0, 1)).toBe("S00E01")
-  })
+    it("handles zero", () => {
+        // Specials are S00 — must not lose the digit
+        expect(epCode(0, 1)).toBe("S00E01")
+    })
 })
 
 describe("libraryShort / libraryLabel", () => {
-  it("returns fallback when libraries are empty", () => {
-    store.libraries = []
-    expect(libraryShort("tv")).toBe("??")
-    expect(libraryLabel("tv")).toBe("tv")  // falls back to id
-  })
+    it("returns fallback when libraries are empty", () => {
+        store.libraries = []
+        expect(libraryShort("tv")).toBe("??")
+        expect(libraryLabel("tv")).toBe("tv") // falls back to id
+    })
 
-  it("returns the API-supplied short and label", () => {
-    store.libraries = [
-      { id: "tv", label: "TV", short: "TV", kind: "show", sync_sub: "tv" },
-      { id: "movies", label: "Movies", short: "MO", kind: "movie", sync_sub: "movies" },
-    ]
-    expect(libraryShort("tv")).toBe("TV")
-    expect(libraryShort("movies")).toBe("MO")
-    expect(libraryLabel("movies")).toBe("Movies")
-  })
+    it("returns the API-supplied short and label", () => {
+        store.libraries = [
+            {
+                id: "tv",
+                label: "TV",
+                short: "TV",
+                kind: "show",
+                sync_sub: "tv",
+            },
+            {
+                id: "movies",
+                label: "Movies",
+                short: "MO",
+                kind: "movie",
+                sync_sub: "movies",
+            },
+        ]
+        expect(libraryShort("tv")).toBe("TV")
+        expect(libraryShort("movies")).toBe("MO")
+        expect(libraryLabel("movies")).toBe("Movies")
+    })
 
-  it("returns fallback for unknown library id", () => {
-    store.libraries = [{ id: "tv", label: "TV", short: "TV", kind: "show", sync_sub: "tv" }]
-    expect(libraryShort("nonexistent")).toBe("??")
-  })
+    it("returns fallback for unknown library id", () => {
+        store.libraries = [
+            {
+                id: "tv",
+                label: "TV",
+                short: "TV",
+                kind: "show",
+                sync_sub: "tv",
+            },
+        ]
+        expect(libraryShort("nonexistent")).toBe("??")
+    })
 })

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -4,37 +4,37 @@ import { fuzzyScore } from "./fuzzy"
 import type { DiskUsage, Job, LibraryInfo, Tab, Title } from "./types"
 
 interface State {
-  // Catalog
-  titles: Title[]
-  disk: DiskUsage | null
-  libraries: LibraryInfo[]
-  loaded: boolean
+    // Catalog
+    titles: Title[]
+    disk: DiskUsage | null
+    libraries: LibraryInfo[]
+    loaded: boolean
 
-  // UI
-  tab: Tab
-  query: string
-  libFilter: Set<string>           // empty = all
-  stateFilter: Set<string>         // empty = all; values: unwatched | watching | synced | new | watchlist
+    // UI
+    tab: Tab
+    query: string
+    libFilter: Set<string> // empty = all
+    stateFilter: Set<string> // empty = all; values: unwatched | watching | synced | new | watchlist
 
-  // Drawer
-  detail: { lib: string; folder: string } | null
+    // Drawer
+    detail: { lib: string; folder: string } | null
 
-  // Tab badge counts. Maintenance is the sum of actionable items
-  // (pending + watched-in-synced + hanging); Watchlist is the watchlist
-  // item count. Refreshed on app mount and after relevant actions.
-  maintenanceCount: number | null
-  watchlistCount: number | null
+    // Tab badge counts. Maintenance is the sum of actionable items
+    // (pending + watched-in-synced + hanging); Watchlist is the watchlist
+    // item count. Refreshed on app mount and after relevant actions.
+    maintenanceCount: number | null
+    watchlistCount: number | null
 
-  // Jobs
-  jobs: Record<string, Job>
-  toasts: Toast[]
+    // Jobs
+    jobs: Record<string, Job>
+    toasts: Toast[]
 }
 
 export interface Toast {
-  id: string
-  kind: "info" | "success" | "error"
-  text: string
-  jobId?: string
+    id: string
+    kind: "info" | "success" | "error"
+    text: string
+    jobId?: string
 }
 
 // Session-only overlay of items the user explicitly marked watched via the
@@ -50,37 +50,52 @@ export interface Toast {
 // by then WatchState should have caught up).
 const scrobbledOverlay = new Set<string>()
 
-function overlayKey(lib: string, folder: string, season: number | null = null, episode: number | null = null): string {
-  return `${lib}/${folder}/${season ?? ""}/${episode ?? ""}`
+function overlayKey(
+    lib: string,
+    folder: string,
+    season: number | null = null,
+    episode: number | null = null
+): string {
+    return `${lib}/${folder}/${season ?? ""}/${episode ?? ""}`
 }
 
-export function recordScrobbled(lib: string, folder: string, season: number | null = null, episode: number | null = null): void {
-  scrobbledOverlay.add(overlayKey(lib, folder, season, episode))
+export function recordScrobbled(
+    lib: string,
+    folder: string,
+    season: number | null = null,
+    episode: number | null = null
+): void {
+    scrobbledOverlay.add(overlayKey(lib, folder, season, episode))
 }
 
 /** True if (lib, folder, season?, episode?) was scrobbled in this session. */
-export function isScrobbledThisSession(lib: string, folder: string, season: number | null = null, episode: number | null = null): boolean {
-  return scrobbledOverlay.has(overlayKey(lib, folder, season, episode))
+export function isScrobbledThisSession(
+    lib: string,
+    folder: string,
+    season: number | null = null,
+    episode: number | null = null
+): boolean {
+    return scrobbledOverlay.has(overlayKey(lib, folder, season, episode))
 }
 
 export const store = reactive<State>({
-  titles: [],
-  disk: null,
-  libraries: [],
-  loaded: false,
+    titles: [],
+    disk: null,
+    libraries: [],
+    loaded: false,
 
-  tab: "library",
-  query: "",
-  libFilter: new Set(),
-  stateFilter: new Set(),
+    tab: "library",
+    query: "",
+    libFilter: new Set(),
+    stateFilter: new Set(),
 
-  detail: null,
+    detail: null,
 
-  maintenanceCount: null,
-  watchlistCount: null,
+    maintenanceCount: null,
+    watchlistCount: null,
 
-  jobs: {},
-  toasts: [],
+    jobs: {},
+    toasts: [],
 })
 
 // ── Loading ────────────────────────────────────────────────────────────────
@@ -88,19 +103,19 @@ export const store = reactive<State>({
 let stateInflight: Promise<void> | null = null
 
 export async function loadState(refresh = false): Promise<void> {
-  if (stateInflight) return stateInflight
-  stateInflight = (async () => {
-    try {
-      const data = await api.state(refresh)
-      store.titles = data.titles
-      store.disk = data.disk
-      store.libraries = data.libraries ?? []
-      store.loaded = true
-    } finally {
-      stateInflight = null
-    }
-  })()
-  return stateInflight
+    if (stateInflight) return stateInflight
+    stateInflight = (async () => {
+        try {
+            const data = await api.state(refresh)
+            store.titles = data.titles
+            store.disk = data.disk
+            store.libraries = data.libraries ?? []
+            store.loaded = true
+        } finally {
+            stateInflight = null
+        }
+    })()
+    return stateInflight
 }
 
 // Tab-badge count loaders. Failures intentionally swallow into null so the
@@ -108,61 +123,66 @@ export async function loadState(refresh = false): Promise<void> {
 // load-bearing.
 
 export async function loadMaintenanceCount(): Promise<void> {
-  try {
-    const r = await api.maintCounts()
-    store.maintenanceCount = r.total
-  } catch {
-    store.maintenanceCount = null
-  }
+    try {
+        const r = await api.maintCounts()
+        store.maintenanceCount = r.total
+    } catch {
+        store.maintenanceCount = null
+    }
 }
 
 export async function loadWatchlistCount(): Promise<void> {
-  try {
-    const r = await api.watchlist()
-    store.watchlistCount = r.items.length
-  } catch {
-    store.watchlistCount = null
-  }
+    try {
+        const r = await api.watchlist()
+        store.watchlistCount = r.items.length
+    } catch {
+        store.watchlistCount = null
+    }
 }
 
 // ── Filters ────────────────────────────────────────────────────────────────
 
 export const filteredTitles = computed<Title[]>(() => {
-  const q = store.query.trim()
-  const lib = store.libFilter
-  const sf = store.stateFilter
+    const q = store.query.trim()
+    const lib = store.libFilter
+    const sf = store.stateFilter
 
-  let list = store.titles
-  if (lib.size > 0) list = list.filter(t => lib.has(t.lib))
+    let list = store.titles
+    if (lib.size > 0) list = list.filter((t) => lib.has(t.lib))
 
-  if (sf.size > 0) {
-    list = list.filter(t => {
-      if (sf.has("synced") && !t.has_synced) return false
-      if (sf.has("unwatched") && t.watched_pct >= 80) return false
-      if (sf.has("watching") && (t.watched_pct === 0 || t.watched_pct >= 100)) return false
-      // "new" = has synced + some eps remain unwatched
-      if (sf.has("new") && !(t.has_synced && t.watched_pct < 100)) return false
-      return true
-    })
-  }
+    if (sf.size > 0) {
+        list = list.filter((t) => {
+            if (sf.has("synced") && !t.has_synced) return false
+            if (sf.has("unwatched") && t.watched_pct >= 80) return false
+            if (
+                sf.has("watching") &&
+                (t.watched_pct === 0 || t.watched_pct >= 100)
+            )
+                return false
+            // "new" = has synced + some eps remain unwatched
+            if (sf.has("new") && !(t.has_synced && t.watched_pct < 100))
+                return false
+            return true
+        })
+    }
 
-  if (!q) return list
+    if (!q) return list
 
-  return list
-    .map(t => ({ t, s: fuzzyScore(q, t.name) }))
-    .filter(x => x.s > 0.1)
-    .sort((a, b) => b.s - a.s)
-    .map(x => x.t)
+    return list
+        .map((t) => ({ t, s: fuzzyScore(q, t.name) }))
+        .filter((x) => x.s > 0.1)
+        .sort((a, b) => b.s - a.s)
+        .map((x) => x.t)
 })
 
 // ── Drawer ─────────────────────────────────────────────────────────────────
 
 export function openDetail(lib: string, folder: string): void {
-  store.detail = { lib, folder }
+    store.detail = { lib, folder }
 }
 
 export function closeDetail(): void {
-  store.detail = null
+    store.detail = null
 }
 
 // ── Jobs ───────────────────────────────────────────────────────────────────
@@ -171,65 +191,66 @@ const JOB_POLL_MS = 600
 const activePolls = new Set<string>()
 
 export interface JobLabel {
-  action: "Sync" | "Unsync"
-  name: string                     // title to render in the toast
-  totalMediaFiles: number          // count of video files (subs/etc. not counted)
+    action: "Sync" | "Unsync"
+    name: string // title to render in the toast
+    totalMediaFiles: number // count of video files (subs/etc. not counted)
 }
 
 function items(n: number): string {
-  return `${n} item${n === 1 ? "" : "s"}`
+    return `${n} item${n === 1 ? "" : "s"}`
 }
 
 export function trackJob(jobId: string, label: JobLabel): void {
-  if (activePolls.has(jobId)) return
-  activePolls.add(jobId)
+    if (activePolls.has(jobId)) return
+    activePolls.add(jobId)
 
-  const toastId = pushToast({
-    kind: "info",
-    text: `${label.action}ing ${label.name} — ${items(label.totalMediaFiles)}`,
-    jobId,
-  })
+    const toastId = pushToast({
+        kind: "info",
+        text: `${label.action}ing ${label.name} — ${items(label.totalMediaFiles)}`,
+        jobId,
+    })
 
-  ;(async () => {
-    try {
-      while (true) {
-        const job = await api.job(jobId)
-        store.jobs[jobId] = job
+    ;(async () => {
+        try {
+            while (true) {
+                const job = await api.job(jobId)
+                store.jobs[jobId] = job
 
-        if (job.status === "done") {
-          const past = label.action === "Sync" ? "Synced" : "Unsynced"
-          const n = job.processed_media_files
-          // Bytes are only meaningful for sync (unsync just deletes); show both
-          // for sync, count-only for unsync.
-          const tail = label.action === "Sync"
-            ? ` (${humanSize(job.processed_bytes)})`
-            : ""
-          updateToast(toastId, {
-            kind: "success",
-            text: `${past} ${label.name} — ${items(n)}${tail}`,
-          })
-          await loadState(true)
-          break
+                if (job.status === "done") {
+                    const past = label.action === "Sync" ? "Synced" : "Unsynced"
+                    const n = job.processed_media_files
+                    // Bytes are only meaningful for sync (unsync just deletes); show both
+                    // for sync, count-only for unsync.
+                    const tail =
+                        label.action === "Sync"
+                            ? ` (${humanSize(job.processed_bytes)})`
+                            : ""
+                    updateToast(toastId, {
+                        kind: "success",
+                        text: `${past} ${label.name} — ${items(n)}${tail}`,
+                    })
+                    await loadState(true)
+                    break
+                }
+                if (job.status === "error") {
+                    updateToast(toastId, {
+                        kind: "error",
+                        text: `${label.action} ${label.name} failed: ${job.error}`,
+                    })
+                    break
+                }
+                await sleep(JOB_POLL_MS)
+            }
+        } finally {
+            activePolls.delete(jobId)
+            // Auto-dismiss after success
+            setTimeout(() => dismissToast(toastId), 4500)
         }
-        if (job.status === "error") {
-          updateToast(toastId, {
-            kind: "error",
-            text: `${label.action} ${label.name} failed: ${job.error}`,
-          })
-          break
-        }
-        await sleep(JOB_POLL_MS)
-      }
-    } finally {
-      activePolls.delete(jobId)
-      // Auto-dismiss after success
-      setTimeout(() => dismissToast(toastId), 4500)
-    }
-  })()
+    })()
 }
 
 function sleep(ms: number): Promise<void> {
-  return new Promise(r => setTimeout(r, ms))
+    return new Promise((r) => setTimeout(r, ms))
 }
 
 // ── Toasts ─────────────────────────────────────────────────────────────────
@@ -237,42 +258,42 @@ function sleep(ms: number): Promise<void> {
 let toastCounter = 0
 
 export function pushToast(t: Omit<Toast, "id">): string {
-  const id = `t${++toastCounter}`
-  store.toasts.push({ id, ...t })
-  return id
+    const id = `t${++toastCounter}`
+    store.toasts.push({ id, ...t })
+    return id
 }
 
 export function updateToast(id: string, patch: Partial<Toast>): void {
-  const t = store.toasts.find(t => t.id === id)
-  if (t) Object.assign(t, patch)
+    const t = store.toasts.find((t) => t.id === id)
+    if (t) Object.assign(t, patch)
 }
 
 export function dismissToast(id: string): void {
-  const i = store.toasts.findIndex(t => t.id === id)
-  if (i >= 0) store.toasts.splice(i, 1)
+    const i = store.toasts.findIndex((t) => t.id === id)
+    if (i >= 0) store.toasts.splice(i, 1)
 }
 
 // ── Format helpers (also used in components) ───────────────────────────────
 
 export function libraryShort(libId: string): string {
-  return store.libraries.find(l => l.id === libId)?.short ?? "??"
+    return store.libraries.find((l) => l.id === libId)?.short ?? "??"
 }
 
 export function libraryLabel(libId: string): string {
-  return store.libraries.find(l => l.id === libId)?.label ?? libId
+    return store.libraries.find((l) => l.id === libId)?.label ?? libId
 }
 
 export function humanSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`
-  const units = ["KB", "MB", "GB", "TB", "PB"]
-  let n = bytes / 1024
-  for (const u of units) {
-    if (n < 1024) return `${n.toFixed(n < 10 ? 1 : 0)} ${u}`
-    n /= 1024
-  }
-  return `${n.toFixed(1)} EB`
+    if (bytes < 1024) return `${bytes} B`
+    const units = ["KB", "MB", "GB", "TB", "PB"]
+    let n = bytes / 1024
+    for (const u of units) {
+        if (n < 1024) return `${n.toFixed(n < 10 ? 1 : 0)} ${u}`
+        n /= 1024
+    }
+    return `${n.toFixed(1)} EB`
 }
 
 export function epCode(s: number, e: number): string {
-  return `S${String(s).padStart(2, "0")}E${String(e).padStart(2, "0")}`
+    return `S${String(s).padStart(2, "0")}E${String(e).padStart(2, "0")}`
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,124 +1,194 @@
 :root {
-  /* Surface */
-  --bg: #0c0e12;
-  --bg-elev: #161a21;
-  --bg-elev-2: #1f2530;
-  --bg-hover: #232a37;
-  --border: #2a3140;
-  --border-strong: #3b4356;
+    /* Surface */
+    --bg: #0c0e12;
+    --bg-elev: #161a21;
+    --bg-elev-2: #1f2530;
+    --bg-hover: #232a37;
+    --border: #2a3140;
+    --border-strong: #3b4356;
 
-  /* Text */
-  --fg: #e6e9ef;
-  --fg-muted: #aab2c2;
-  --fg-dim: #6f7689;
+    /* Text */
+    --fg: #e6e9ef;
+    --fg-muted: #aab2c2;
+    --fg-dim: #6f7689;
 
-  /* Accents — mirror the CLI color palette so muscle memory carries over */
-  --accent-sync: #29d0d0;       /* cyan — synced */
-  --accent-watched: #4caf6c;    /* green — watched */
-  --accent-progress: #f0a838;   /* amber — in-progress / new */
-  --accent-action: #6c8eef;     /* blue — primary action */
-  --danger: #e0524c;
+    /* Accents — mirror the CLI color palette so muscle memory carries over */
+    --accent-sync: #29d0d0; /* cyan — synced */
+    --accent-watched: #4caf6c; /* green — watched */
+    --accent-progress: #f0a838; /* amber — in-progress / new */
+    --accent-action: #6c8eef; /* blue — primary action */
+    --danger: #e0524c;
 
-  /* Layout */
-  --radius: 8px;
-  --radius-lg: 12px;
-  --shadow: 0 4px 20px rgba(0, 0, 0, 0.35);
+    /* Layout */
+    --radius: 8px;
+    --radius-lg: 12px;
+    --shadow: 0 4px 20px rgba(0, 0, 0, 0.35);
 
-  color-scheme: dark;
-  color: var(--fg);
-  background: var(--bg);
+    color-scheme: dark;
+    color: var(--fg);
+    background: var(--bg);
 
-  font-family:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", system-ui,
-    Helvetica, Arial, sans-serif;
-  font-size: 15px;
-  line-height: 1.45;
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
+    font-family:
+        -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", system-ui,
+        Helvetica, Arial, sans-serif;
+    font-size: 15px;
+    line-height: 1.45;
+    font-synthesis: none;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
 }
 
-* { box-sizing: border-box; }
-
-html, body, #app {
-  margin: 0;
-  padding: 0;
-  height: 100%;
-  overscroll-behavior-y: none;
+* {
+    box-sizing: border-box;
 }
 
-body { background: var(--bg); }
+html,
+body,
+#app {
+    margin: 0;
+    padding: 0;
+    height: 100%;
+    overscroll-behavior-y: none;
+}
 
-a { color: var(--accent-action); text-decoration: none; }
-a:hover { text-decoration: underline; }
+body {
+    background: var(--bg);
+}
+
+a {
+    color: var(--accent-action);
+    text-decoration: none;
+}
+a:hover {
+    text-decoration: underline;
+}
 
 button {
-  font: inherit;
-  color: var(--fg);
-  background: var(--bg-elev-2);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 0.5rem 0.85rem;
-  cursor: pointer;
-  transition: background 120ms ease, border-color 120ms ease, transform 80ms ease;
+    font: inherit;
+    color: var(--fg);
+    background: var(--bg-elev-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.5rem 0.85rem;
+    cursor: pointer;
+    transition:
+        background 120ms ease,
+        border-color 120ms ease,
+        transform 80ms ease;
 }
-button:hover { background: var(--bg-hover); border-color: var(--border-strong); }
-button:active { transform: translateY(1px); }
-button:disabled { opacity: 0.5; cursor: not-allowed; }
+button:hover {
+    background: var(--bg-hover);
+    border-color: var(--border-strong);
+}
+button:active {
+    transform: translateY(1px);
+}
+button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
 button.primary {
-  background: var(--accent-action);
-  border-color: var(--accent-action);
-  color: #fff;
-  font-weight: 600;
+    background: var(--accent-action);
+    border-color: var(--accent-action);
+    color: #fff;
+    font-weight: 600;
 }
-button.primary:hover { background: #5478de; border-color: #5478de; }
+button.primary:hover {
+    background: #5478de;
+    border-color: #5478de;
+}
 button.danger {
-  background: var(--danger);
-  border-color: var(--danger);
-  color: #fff;
+    background: var(--danger);
+    border-color: var(--danger);
+    color: #fff;
 }
-button.danger:hover { background: #c9433d; border-color: #c9433d; }
+button.danger:hover {
+    background: #c9433d;
+    border-color: #c9433d;
+}
 button.ghost {
-  background: transparent;
+    background: transparent;
 }
 
-input, select, textarea {
-  font: inherit;
-  color: var(--fg);
-  background: var(--bg-elev-2);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 0.55rem 0.85rem;
-  width: 100%;
+input,
+select,
+textarea {
+    font: inherit;
+    color: var(--fg);
+    background: var(--bg-elev-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0.55rem 0.85rem;
+    width: 100%;
 }
-input:focus, select:focus, textarea:focus {
-  outline: none;
-  border-color: var(--accent-action);
-  box-shadow: 0 0 0 3px rgba(108, 142, 239, 0.18);
+input:focus,
+select:focus,
+textarea:focus {
+    outline: none;
+    border-color: var(--accent-action);
+    box-shadow: 0 0 0 3px rgba(108, 142, 239, 0.18);
 }
 
 /* Scrollbar — slim, themed */
-::-webkit-scrollbar { width: 10px; height: 10px; }
-::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: var(--border); border-radius: 10px; }
-::-webkit-scrollbar-thumb:hover { background: var(--border-strong); }
+::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+}
+::-webkit-scrollbar-track {
+    background: transparent;
+}
+::-webkit-scrollbar-thumb {
+    background: var(--border);
+    border-radius: 10px;
+}
+::-webkit-scrollbar-thumb:hover {
+    background: var(--border-strong);
+}
 
 /* Utility */
-.dim { color: var(--fg-dim); }
-.muted { color: var(--fg-muted); }
-.row { display: flex; align-items: center; gap: 0.5rem; }
-.col { display: flex; flex-direction: column; gap: 0.5rem; }
-.spacer { flex: 1; }
-.mono { font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; }
+.dim {
+    color: var(--fg-dim);
+}
+.muted {
+    color: var(--fg-muted);
+}
+.row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+.col {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+.spacer {
+    flex: 1;
+}
+.mono {
+    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+}
 
 /* Animations */
 @keyframes fade-in {
-  from { opacity: 0; transform: translateY(4px); }
-  to   { opacity: 1; transform: translateY(0); }
+    from {
+        opacity: 0;
+        transform: translateY(4px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
-.fade-in { animation: fade-in 180ms ease-out; }
+.fade-in {
+    animation: fade-in 180ms ease-out;
+}
 
 @keyframes spin {
-  to { transform: rotate(360deg); }
+    to {
+        transform: rotate(360deg);
+    }
 }
-.spin { animation: spin 1s linear infinite; }
+.spin {
+    animation: spin 1s linear infinite;
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,286 +1,305 @@
 export type Kind = "show" | "movie" | "youtube"
 
 export interface Title {
-  id: string
-  lib: string
-  folder: string
-  name: string
-  kind: Kind
-  year: number | null
-  ep_count: number
-  synced_files: number
-  has_synced: boolean
-  watched_count: number
-  watched_pct: number
-  synced_pct: number
+    id: string
+    lib: string
+    folder: string
+    name: string
+    kind: Kind
+    year: number | null
+    ep_count: number
+    synced_files: number
+    has_synced: boolean
+    watched_count: number
+    watched_pct: number
+    synced_pct: number
 }
 
 export interface Episode {
-  season: number
-  episode: number
-  title: string
-  size_bytes: number
-  files: string[]
-  is_synced: boolean
-  watch_state: "watched" | "unwatched" | "progress"
-  watch_pct: number
+    season: number
+    episode: number
+    title: string
+    size_bytes: number
+    files: string[]
+    is_synced: boolean
+    watch_state: "watched" | "unwatched" | "progress"
+    watch_pct: number
 }
 
 export interface Season {
-  season: number
-  total_bytes: number
-  synced_episodes: number
-  watched_episodes: number
-  episodes: Episode[]
+    season: number
+    total_bytes: number
+    synced_episodes: number
+    watched_episodes: number
+    episodes: Episode[]
 }
 
 export interface MovieFile {
-  path: string
-  name: string
-  size_bytes: number
-  is_video: boolean
-  is_synced: boolean
+    path: string
+    name: string
+    size_bytes: number
+    is_video: boolean
+    is_synced: boolean
 }
 
 export interface TitleDetail {
-  id: string
-  lib: string
-  folder: string
-  name: string
-  kind: Kind
-  year: number | null
-  total_bytes: number
-  synced_bytes: number
-  files: MovieFile[]
-  seasons: Season[]
-  watched_episodes?: number
-  watched?: boolean
+    id: string
+    lib: string
+    folder: string
+    name: string
+    kind: Kind
+    year: number | null
+    total_bytes: number
+    synced_bytes: number
+    files: MovieFile[]
+    seasons: Season[]
+    watched_episodes?: number
+    watched?: boolean
 }
 
 export interface DiskUsage {
-  total: number
-  used: number
-  free: number
-  pct: number
-  synced_titles: number
-  synced_bytes: number
+    total: number
+    used: number
+    free: number
+    pct: number
+    synced_titles: number
+    synced_bytes: number
 }
 
 export interface LibraryInfo {
-  id: string
-  label: string
-  short: string
-  kind: Kind
-  sync_sub: string
+    id: string
+    label: string
+    short: string
+    kind: Kind
+    sync_sub: string
 }
 
 export interface StateBundle {
-  titles: Title[]
-  disk: DiskUsage
-  libraries: LibraryInfo[]
+    titles: Title[]
+    disk: DiskUsage
+    libraries: LibraryInfo[]
 }
 
 export interface Job {
-  id: string
-  op: "sync" | "unsync"
-  status: "queued" | "running" | "done" | "error"
-  total_files: number
-  total_media_files: number
-  processed_files: number
-  processed_media_files: number
-  processed_bytes: number
-  total_bytes: number
-  current_file: string
-  title: string
-  started_at: number
-  ended_at: number
-  error: string
+    id: string
+    op: "sync" | "unsync"
+    status: "queued" | "running" | "done" | "error"
+    total_files: number
+    total_media_files: number
+    processed_files: number
+    processed_media_files: number
+    processed_bytes: number
+    total_bytes: number
+    current_file: string
+    title: string
+    started_at: number
+    ended_at: number
+    error: string
 }
 
 export interface SyncedEntry {
-  title: string
-  folder: string
-  lib: string | null
-  kind: string
-  size_bytes: number
-  new_unwatched: { season: number; episode: number; title: string; size_bytes: number }[]
+    title: string
+    folder: string
+    lib: string | null
+    kind: string
+    size_bytes: number
+    new_unwatched: {
+        season: number
+        episode: number
+        title: string
+        size_bytes: number
+    }[]
 }
 
 export interface WatchlistEntry {
-  title: string
-  category: string
-  guid: string
-  matched: boolean
-  lib?: string
-  folder?: string
-  name?: string
-  watched_pct?: number
-  synced_pct?: number
-  kind?: Kind
+    title: string
+    category: string
+    guid: string
+    matched: boolean
+    lib?: string
+    folder?: string
+    name?: string
+    watched_pct?: number
+    synced_pct?: number
+    kind?: Kind
 }
 
 export interface WatchedFiles {
-  title: string
-  lib: string
-  folder: string
-  files: string[]
-  size_bytes: number
-  file_count: number
+    title: string
+    lib: string
+    folder: string
+    files: string[]
+    size_bytes: number
+    file_count: number
 }
 
 export interface HangingFile {
-  path: string
-  rel: string
-  size_bytes: number
+    path: string
+    rel: string
+    size_bytes: number
 }
 
 export interface ResolveResult {
-  found: boolean
-  lib?: string
-  folder?: string
-  name?: string
-  kind?: Kind
-  reason?: string
-  match_method?: string
-  via?: string
+    found: boolean
+    lib?: string
+    folder?: string
+    name?: string
+    kind?: Kind
+    reason?: string
+    match_method?: string
+    via?: string
 }
 
-export type Tab = "library" | "synced" | "watchlist" | "maintenance" | "syncthing"
+export type Tab =
+    | "library"
+    | "synced"
+    | "watchlist"
+    | "maintenance"
+    | "syncthing"
 
 export interface SyncthingDevice {
-  device_id: string
-  name: string
-  completion: number
-  need_bytes: number
-  connected: boolean
-  paused: boolean
+    device_id: string
+    name: string
+    completion: number
+    need_bytes: number
+    connected: boolean
+    paused: boolean
 }
 
 export interface SyncthingFolder {
-  folder_id: string
-  label: string
-  percent: number
-  state: string
-  need_bytes: number
-  in_sync_bytes: number
-  global_bytes: number
-  devices: SyncthingDevice[]
+    folder_id: string
+    label: string
+    percent: number
+    state: string
+    need_bytes: number
+    in_sync_bytes: number
+    global_bytes: number
+    devices: SyncthingDevice[]
 }
 
 export interface SyncthingOverview {
-  configured: boolean
-  folders: SyncthingFolder[]
+    configured: boolean
+    folders: SyncthingFolder[]
 }
 
 export interface PendingEpisode {
-  season: number
-  episode: number
-  already_watched_in_plex: boolean
-  episode_rating_key: string | null
-  title: string
+    season: number
+    episode: number
+    already_watched_in_plex: boolean
+    episode_rating_key: string | null
+    title: string
 }
 
 export interface PendingSeason {
-  season: number
-  episodes: PendingEpisode[]
+    season: number
+    episodes: PendingEpisode[]
 }
 
 export interface PendingGroup {
-  sync_sub: string
-  folder: string
-  title: string
-  kind: Kind
-  lib: string | null
-  rating_key: string | null
-  // movie-only:
-  already_watched_in_plex?: boolean
-  // show / youtube only:
-  seasons?: PendingSeason[]
+    sync_sub: string
+    folder: string
+    title: string
+    kind: Kind
+    lib: string | null
+    rating_key: string | null
+    // movie-only:
+    already_watched_in_plex?: boolean
+    // show / youtube only:
+    seasons?: PendingSeason[]
 }
 
 export interface PendingItemRef {
-  sync_sub: string
-  folder: string
-  season?: number | null
-  episode?: number | null
+    sync_sub: string
+    folder: string
+    season?: number | null
+    episode?: number | null
 }
 
 export type ResolveAction = "confirm" | "reject"
 
 export type ResolveStatus =
-  | "ok"
-  | "scrobble_failed"
-  | "no_rating_key"
-  | "rejected"
+    | "ok"
+    | "scrobble_failed"
+    | "no_rating_key"
+    | "rejected"
 
 export interface ResolveItemResult {
-  sync_sub: string
-  folder: string
-  season: number | null
-  episode: number | null
-  status: ResolveStatus
+    sync_sub: string
+    folder: string
+    season: number | null
+    episode: number | null
+    status: ResolveStatus
 }
 
 export interface CleanupSummary {
-  removed_files: number
-  removed_dirs: number
+    removed_files: number
+    removed_dirs: number
 }
 
 export interface ResolveResponse {
-  results: ResolveItemResult[]
-  cleanup: CleanupSummary
-  error?: string
+    results: ResolveItemResult[]
+    cleanup: CleanupSummary
+    error?: string
 }
 
 export interface RemoveResponse {
-  removed: number
-  bytes_freed: number
-  cleanup: CleanupSummary
+    removed: number
+    bytes_freed: number
+    cleanup: CleanupSummary
 }
 
 export type ScrobbleScope = "movie" | "series" | "season" | "episode"
 
 export interface ScrobbleItemResult {
-  season: number | null
-  episode: number | null
-  status: "ok" | "scrobble_failed" | "no_rating_key"
+    season: number | null
+    episode: number | null
+    status: "ok" | "scrobble_failed" | "no_rating_key"
 }
 
 export interface ScrobbleResponse {
-  scrobbled: number
-  failed: number
-  results: ScrobbleItemResult[]
-  error?: string
+    scrobbled: number
+    failed: number
+    results: ScrobbleItemResult[]
+    error?: string
 }
 
 export interface MaintenanceCounts {
-  watched_titles: number
-  hanging_files: number
-  pending_items: number
-  total: number
+    watched_titles: number
+    hanging_files: number
+    pending_items: number
+    total: number
 }
 
 export type IgnoreKind = "pending" | "watched" | "hanging"
 
 export interface IgnoredPendingRef {
-  sync_sub: string
-  folder: string
-  season: number | null
-  episode: number | null
+    sync_sub: string
+    folder: string
+    season: number | null
+    episode: number | null
 }
 
 export interface IgnoredWatchedRef {
-  lib: string
-  folder: string
+    lib: string
+    folder: string
 }
 
 export interface IgnoredHangingRef {
-  path: string
+    path: string
 }
 
+// Discriminated union over the three ignore-able entry shapes. Single source
+// of truth for the wire contract; backend route /api/maintenance/ignore
+// branches on `kind` and reads the matching ref. Keep this aligned with
+// backend/synclet/ignored.py:ignore_ref().
+export type IgnoreOp =
+    | { kind: "watched"; ref: IgnoredWatchedRef }
+    | { kind: "hanging"; ref: IgnoredHangingRef }
+    | { kind: "pending"; ref: IgnoredPendingRef }
+
 export interface IgnoredGrouped {
-  version: number
-  pending: IgnoredPendingRef[]
-  watched: IgnoredWatchedRef[]
-  hanging: IgnoredHangingRef[]
+    version: number
+    pending: IgnoredPendingRef[]
+    watched: IgnoredWatchedRef[]
+    hanging: IgnoredHangingRef[]
 }

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,14 @@
 /// <reference types="vite/client" />
+
+// Vue Single File Component module shim. Without this, `import X from "./X.vue"`
+// types `X` as `any`, which silently defeats every downstream type-aware lint
+// rule (no-unsafe-argument, no-unsafe-call, etc.).
+declare module "*.vue" {
+    import type { DefineComponent } from "vue"
+    const component: DefineComponent<
+        Record<string, never>,
+        Record<string, never>,
+        unknown
+    >
+    export default component
+}

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,15 +1,15 @@
 {
-  "extends": "@vue/tsconfig/tsconfig.dom.json",
-  "compilerOptions": {
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "extends": "@vue/tsconfig/tsconfig.dom.json",
+    "compilerOptions": {
+        "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
 
-    /* Linting */
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
-  },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"]
+        /* Linting */
+        "strict": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "erasableSyntaxOnly": true,
+        "noFallthroughCasesInSwitch": true,
+        "noUncheckedSideEffectImports": true
+    },
+    "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"]
 }

--- a/frontend/tsconfig.eslint.json
+++ b/frontend/tsconfig.eslint.json
@@ -1,0 +1,9 @@
+{
+    "extends": "./tsconfig.app.json",
+    "compilerOptions": {
+        "noUnusedLocals": false,
+        "noUnusedParameters": false
+    },
+    "include": ["src/**/*.ts", "src/**/*.vue", "*.ts", "*.cjs"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,7 +1,7 @@
 {
-  "files": [],
-  "references": [
-    { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
-  ]
+    "files": [],
+    "references": [
+        { "path": "./tsconfig.app.json" },
+        { "path": "./tsconfig.node.json" }
+    ]
 }

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,25 +1,25 @@
 {
-  "compilerOptions": {
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
-    "target": "ES2023",
-    "lib": ["ES2023"],
-    "module": "ESNext",
-    "skipLibCheck": true,
+    "compilerOptions": {
+        "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+        "target": "ES2023",
+        "lib": ["ES2023"],
+        "module": "ESNext",
+        "skipLibCheck": true,
 
-    /* Bundler mode */
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "verbatimModuleSyntax": true,
-    "moduleDetection": "force",
-    "noEmit": true,
+        /* Bundler mode */
+        "moduleResolution": "bundler",
+        "allowImportingTsExtensions": true,
+        "verbatimModuleSyntax": true,
+        "moduleDetection": "force",
+        "noEmit": true,
 
-    /* Linting */
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "erasableSyntaxOnly": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
-  },
-  "include": ["vite.config.ts"]
+        /* Linting */
+        "strict": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "erasableSyntaxOnly": true,
+        "noFallthroughCasesInSwitch": true,
+        "noUncheckedSideEffectImports": true
+    },
+    "include": ["vite.config.ts"]
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -18,7 +18,9 @@ export default defineConfig(({ mode }) => ({
             mode === "development"
                 ? {
                       "/api": {
-                          target: process.env.VITE_BACKEND_URL || "http://localhost:1314",
+                          target:
+                              process.env.VITE_BACKEND_URL ||
+                              "http://localhost:1314",
                           changeOrigin: true,
                       },
                   }


### PR DESCRIPTION
Closes #32.

## What

Wires the previously aspirational eslint.config.cjs + .prettierrc into the build, then fixes everything that wiring surfaced — including a silently-broken `pnpm build` on main that no CI was gating.

## Wiring

- Install eslint, prettier, eslint-plugin-vue, eslint-plugin-prettier, @typescript-eslint/{parser,eslint-plugin}, vue-eslint-parser, eslint-config-prettier, @types/node.
- Add `lint` + `format` scripts to frontend/package.json.
- Rewrite eslint.config.cjs against the current v10 / v8 flat-config plugin API (the existing config referenced stale paths and never actually loaded). Curated rule set, NOT `select=ALL`: type-aware safety rules (no-unsafe-*, no-non-null-assertion, no-explicit-any, prefer-readonly) + Vue 3 recommended + prettier-as-eslint. Drops strict-boolean-expressions (fights Vue truthy-check idioms).
- Create tsconfig.eslint.json so type-aware rules have a project.
- Add .pnpm-store/ to .prettierignore.
- Add `**/*.test.ts` override that disables no-non-null-assertion (vitest's idiomatic post-toBeDefined() pattern).

## Surfaced and fixed

- `pnpm build` was silently broken on main (no CI gates it). Added @types/node for vite.config.ts. Added Vue SFC module shim to vite-env.d.ts so `*.vue` imports aren't any-typed — that was defeating main.ts type safety.
- MaintenanceView.vue carried `ref: any` on `ignoreItem` / `unignoreItem` / `removePendingLocal`. Replaced with discriminated `IgnoreOp` union (moved into types.ts so api.ts shares the same wire contract — previous `ref: object` signature gave no safety).
- DetailDrawer.vue: extracted `parseKey()` helper (used 2x for sync/unsync episode parsing); guarded `seed` and `ep` against `noUncheckedIndexedAccess` undefined-from-index; removed `lastClick.value!` non-null assertions via local const narrowing.
- JobToasts.vue: extracted `runningJob()` + `jobWidth()` helpers; template no longer juggles three nested `t.jobId && store.jobs[t.jobId] && ...` accesses.
- EpisodeTile.vue: dropped unused season/episode params from onKey (the click bridge carries them via $emit; args were vestigial).
- SyncthingView.test.ts: typed HAPPY_FOLDER + HAPPY_OVERVIEW so spread-an-indexed-folder type-checks.
- Dropped `ONLY_WARN=true` escape hatch and the eslint-plugin-only-warn devDep that existed only to serve it. Nothing referenced it.

## Tests added (sr-dev-review fill-in)

- **MaintenanceView.test.ts** (+3): contract tests pinning the `{kind, ref}` wire body shape for each IgnoreKind variant (watched, hanging, pending). Backend route branches on kind; this is the bug class that ships silently otherwise (422 only at click time).
- **JobToasts.test.ts** (new, 6 tests): running / done / no-jobId / missing-from-store / processed>total clamp / zero total_bytes.
- **EpisodeTile.test.ts** (new, 5 tests): Enter/Space activation, shift modifier propagation, non-activation keys ignored, preventDefault on Space.

32 → 46 tests across 5 → 7 files; 100% pass.

## Live verification

- \`pnpm lint\` exit 0 (eslint + prettier --check)
- \`pnpm build\` exit 0 (vue-tsc -b + vite build)
- \`pnpm test\` exit 0 (46/46)
- Wire-contract probe against the live synclet-backend-1 container:
  - POST /api/maintenance/ignore   {kind:'watched',  ref:{lib,folder}}                    → 201 ok
  - POST /api/maintenance/ignore   {kind:'hanging',  ref:{path}}                          → 201 ok
  - POST /api/maintenance/ignore   {kind:'pending',  ref:{sync_sub,folder,season,episode}}→ 201 ok
  - Same three with /unignore → 201 ok
- Vite dev server HMR'd every edit across the whole session with zero compile errors in its log.

**Visual artifact note**: no browser screenshot — pocket-dev has no headless browser. The diff is 99% mechanical reformat (prettier whitespace, DOM-identical by construction); behavioral changes are covered by the 14 new mount tests + the live wire probe above.

## Diff size

~5969+/3367- because prettier reformatted every file (2-space → 4-space per the existing but unenforced .prettierrc). One-time cost; all future diffs benefit. Reviewers: diff with \`-w\` to see real changes.

## Out of scope (filed elsewhere)

The issue body called out pre-commit hooks and CI workflow as separate concerns. Both still apply — not adding either here.