### PR TITLE
feat(ci): build + publish Synclet image to GHCR on push to dev/main

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,37 @@
+# Keep the build context small. The production Dockerfile only needs
+# frontend/ + backend/, never the dev-only stuff below.
+
+# Build/test artifacts
+**/node_modules
+**/.venv
+**/__pycache__
+**/.pytest_cache
+**/.ruff_cache
+**/.mypy_cache
+**/dist
+**/.pnpm-store
+**/.tmp
+
+# VCS, CI, editor noise
+.git
+.github
+.vscode
+.idea
+*.swp
+
+# Local-only data
+backend/data
+frontend/coverage
+*.log
+
+# Compose files — the production image is launched by docker-compose.prod.yml
+# OUTSIDE the image, so neither compose file belongs in the build context.
+docker-compose*.yml
+
+# Dev Dockerfile is not used by the prod build.
+Dockerfile.dev
+
+# Secrets and env files — never copy into an image layer.
+.env
+.env.*
+!.env.example

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,79 @@
+name: ci
+
+# Gate every PR and every push to dev/main on:
+#   - backend: ruff format --check, ruff check, pyright, pytest with 90% gate
+#   - frontend: eslint, prettier --check, vue-tsc + vite build, vitest
+# Both jobs run in parallel. Image building/publishing is the separate
+# publish.yml workflow that runs only after this passes on dev or main.
+
+on:
+    pull_request:
+        branches: [main, dev]
+    push:
+        branches: [main, dev]
+
+# Cancel in-flight runs when a new push lands on the same ref — saves
+# minutes when force-pushing during PR review.
+concurrency:
+    group: ci-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    backend:
+        runs-on: ubuntu-latest
+        defaults:
+            run:
+                working-directory: backend
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@v6
+              with:
+                  # Pin matches Dockerfile and Dockerfile.dev. Bump together.
+                  version: "0.11.15"
+                  enable-cache: true
+
+            # uv manages the Python toolchain itself — pyproject.toml pins
+            # >=3.14, uv resolves and installs the matching interpreter.
+            - name: Sync deps
+              run: uv sync --frozen
+
+            - name: Lint (ruff format --check + ruff check + pyright)
+              run: ./lint.sh
+
+            - name: Test (pytest with 90% coverage gate)
+              run: uv run pytest
+
+    frontend:
+        runs-on: ubuntu-latest
+        defaults:
+            run:
+                working-directory: frontend
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  # Pin matches Dockerfile + Dockerfile.dev. Bump together.
+                  version: 11.1.3
+
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "24"
+                  cache: pnpm
+                  cache-dependency-path: frontend/pnpm-lock.yaml
+
+            - name: Install
+              run: pnpm install --frozen-lockfile
+
+            - name: Lint (eslint + prettier --check)
+              run: pnpm lint
+
+            - name: Build (vue-tsc + vite build)
+              run: pnpm build
+
+            - name: Test (vitest)
+              run: pnpm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,99 @@
+name: publish
+
+# Builds and pushes the production Synclet image to GHCR.
+# Triggers ONLY on push to dev or main, AND only after ci.yml succeeds on
+# the same commit. We do not publish from PRs (no fork-trust story for
+# write:packages) and we do not publish from feature branches.
+#
+# Tags:
+#   - push to dev:  ghcr.io/jacob-lasky/synclet:dev    + :<sha>
+#   - push to main: ghcr.io/jacob-lasky/synclet:latest + :<sha>
+#
+# Redeploy on Tower is manual via the /ship skill — there is no auto-pull
+# (no Watchtower, no SSH webhook). See memory/project_synclet_deploy_shape.md.
+
+on:
+    workflow_run:
+        workflows: [ci]
+        types: [completed]
+        branches: [main, dev]
+
+permissions:
+    contents: read
+    packages: write
+
+jobs:
+    publish:
+        # Only publish when the upstream ci run succeeded. workflow_run fires
+        # on every completion (including failures and cancels); without this
+        # gate we'd happily ship a broken image.
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  # workflow_run runs against the default branch by default;
+                  # check out the SHA that ci.yml just blessed instead.
+                  ref: ${{ github.event.workflow_run.head_sha }}
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+
+            - name: Log in to GHCR
+              uses: docker/login-action@v3
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Resolve tags
+              id: tags
+              run: |
+                  # The branch name lives on the upstream ci event, not on
+                  # this workflow_run's own ref (which is main). head_branch
+                  # is the source-of-truth.
+                  branch="${{ github.event.workflow_run.head_branch }}"
+                  sha="${{ github.event.workflow_run.head_sha }}"
+                  short_sha="${sha:0:7}"
+
+                  case "$branch" in
+                      main) channel=latest ;;
+                      dev)  channel=dev ;;
+                      *)
+                          echo "unexpected branch '$branch' — refusing to publish"
+                          exit 1
+                          ;;
+                  esac
+
+                  image="ghcr.io/jacob-lasky/synclet"
+                  {
+                      echo "tags<<EOF"
+                      echo "${image}:${channel}"
+                      echo "${image}:${short_sha}"
+                      echo "EOF"
+                  } >> "$GITHUB_OUTPUT"
+                  echo "channel=$channel" >> "$GITHUB_OUTPUT"
+                  echo "short_sha=$short_sha" >> "$GITHUB_OUTPUT"
+
+            - name: Build and push
+              uses: docker/build-push-action@v6
+              with:
+                  context: .
+                  file: Dockerfile
+                  push: true
+                  tags: ${{ steps.tags.outputs.tags }}
+                  # GHA cache for buildx — speeds up subsequent builds when
+                  # only source changes, not deps.
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max
+                  # amd64 only. Tower is x86_64; multi-arch buys nothing
+                  # today and doubles the build time.
+                  platforms: linux/amd64
+
+            - name: Summary
+              run: |
+                  echo "## Published" >> "$GITHUB_STEP_SUMMARY"
+                  echo "" >> "$GITHUB_STEP_SUMMARY"
+                  echo "- channel: \`${{ steps.tags.outputs.channel }}\`" >> "$GITHUB_STEP_SUMMARY"
+                  echo "- sha tag: \`${{ steps.tags.outputs.short_sha }}\`" >> "$GITHUB_STEP_SUMMARY"
+                  echo "- pull: \`docker pull ghcr.io/jacob-lasky/synclet:${{ steps.tags.outputs.channel }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,81 @@
+# syntax=docker/dockerfile:1.6
+#
+# Production image. ONE container: built Vue SPA + Litestar backend + uv venv.
+# Built and published by .github/workflows/publish.yml on push to dev or main.
+# DO NOT use for dev: Dockerfile.dev runs Vite + uvicorn --reload with bind
+# mounts. This image bakes a static dist/ and an immutable venv.
+
+# ─ Stage 1: build the frontend ────────────────────────────────────────────
+FROM node:24-slim AS frontend-builder
+
+WORKDIR /app
+
+# corepack pins pnpm to the version in packageManager (or 11.1.3 fallback to
+# match Dockerfile.dev). Without --activate, pnpm shells through corepack
+# every invocation and adds noise.
+RUN corepack enable && corepack prepare pnpm@11.1.3 --activate
+
+# Cache the dep layer separately from source so source-only changes don't
+# bust pnpm install.
+COPY frontend/pnpm-lock.yaml frontend/package.json frontend/pnpm-workspace.yaml ./
+RUN pnpm install --frozen-lockfile
+
+COPY frontend/ ./
+RUN pnpm build
+# Litestar's static handler with html_mode=True serves 404.html on missing
+# files. Vite doesn't emit one, so any unknown path (typo'd bookmark, future
+# vue-router HTML5 route) would return a bare 404. Cloning index.html to
+# 404.html makes the response body be the SPA shell — Vue mounts and renders
+# the default view. Note: the HTTP status is still 404, not 200; Litestar's
+# html_mode preserves the missing-file status. Functionally fine for Synclet
+# today (no client-side routing, no CDN in front). If/when vue-router lands
+# with HTML5 history mode, swap to a custom catch-all handler returning 200.
+RUN cp dist/index.html dist/404.html
+# After this stage: /app/dist contains the static SPA bundle + 404 fallback.
+
+
+# ─ Stage 2: backend deps via uv ───────────────────────────────────────────
+FROM ghcr.io/astral-sh/uv:0.11.15-python3.14-trixie-slim AS backend-builder
+
+WORKDIR /app
+
+# Venv outside /app so the runtime stage can copy /opt/venv independently of
+# the source tree. Matches the dev image layout.
+ENV UV_PROJECT_ENVIRONMENT=/opt/venv
+
+# Lockfile first for layer caching; --frozen pins the resolved versions.
+# DO NOT use uv.lock* (wildcard) here — that pattern silently tolerates a
+# missing lockfile, after which `--frozen` would fail with a confusing
+# message instead of failing here at copy time with a clear "uv.lock missing".
+COPY backend/pyproject.toml backend/uv.lock ./
+RUN uv sync --frozen --no-cache --link-mode copy --no-dev
+
+
+# ─ Stage 3: runtime ───────────────────────────────────────────────────────
+# Same uv base — gives us a fully-functional python 3.14 without pulling a
+# second large layer. The runtime doesn't need uv itself, but the base is
+# small and matches the build env exactly.
+FROM ghcr.io/astral-sh/uv:0.11.15-python3.14-trixie-slim AS runtime
+
+WORKDIR /app
+
+ENV UV_PROJECT_ENVIRONMENT=/opt/venv \
+    PYTHONUNBUFFERED=1 \
+    PATH="/opt/venv/bin:$PATH" \
+    SYNCLET_STATIC_DIR=/app/static
+
+# Backend source + frontend bundle. Order matters for cache: source changes
+# more often than venv contents.
+COPY --from=backend-builder /opt/venv /opt/venv
+COPY --from=frontend-builder /app/dist /app/static
+COPY backend/ /app/
+
+# Single port: Litestar serves API + SPA + assets from 1314.
+EXPOSE 1314
+
+# Image label so GHCR links back to the repo; ghcr.io picks this up.
+LABEL org.opencontainers.image.source="https://github.com/Jacob-Lasky/Synclet"
+
+# uvicorn directly (no --reload). uv run here would re-resolve deps at start;
+# the venv is already in place from Stage 2, so call the binary directly.
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "1314"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -7,14 +7,16 @@ read like a contract: every endpoint the frontend touches is listed here.
 from __future__ import annotations
 
 import contextlib
+from pathlib import Path
 
 from litestar import Litestar, MediaType, Response, get, post
 from litestar.config.cors import CORSConfig
 from litestar.exceptions import NotFoundException
+from litestar.static_files import create_static_files_router
 from pydantic import BaseModel
 
 from common.log_utils import get_logger
-from synclet import ignored, pending, sync_ops, syncthing
+from synclet import config, ignored, pending, sync_ops, syncthing
 from synclet.plex import fetch_art_bytes, fetch_thumb_bytes
 from synclet.resolve import resolve_url
 from synclet.scan import scan_title_detail, title_detail_to_dict
@@ -454,8 +456,22 @@ async def api_syncthing_overview() -> dict:
     return {"configured": True, "folders": await syncthing.overview()}
 
 
-app = Litestar(
-    route_handlers=[
+def build_route_handlers(static_dir: Path | None = None) -> list:
+    """Assemble the route_handlers list for Litestar.
+
+    The API routes are listed literally; the optional static-files router is
+    appended LAST so Litestar's path specificity prefers the literal /api/...
+    matches over the static catchall rooted at /. If you reorder this list
+    so the static router comes first, /api/* requests will be poached and
+    return HTML instead of JSON — the contract test in tests/test_api.py
+    pins this ordering.
+
+    static_dir: the built Vue dist. None (dev) means no static handler is
+    added; the dev frontend runs separately on :1313. A non-None Path that
+    doesn't exist on disk is also ignored — saves a startup crash if the
+    env var points somewhere stale.
+    """
+    handlers: list = [
         health,
         api_state,
         api_title,
@@ -480,6 +496,27 @@ app = Litestar(
         api_resolve,
         api_refresh,
         api_syncthing_overview,
-    ],
+    ]
+
+    if static_dir is not None and static_dir.is_dir():
+        logger.info("Serving static frontend from %s", static_dir)
+        # html_mode=True serves index.html from / and 404.html on missing
+        # files. The production Dockerfile copies index.html -> 404.html so
+        # unknown paths still render the SPA shell (Vue mounts, default view
+        # renders). Status code on the fallback is 404, not 200; acceptable
+        # for Synclet which has no client-side URL routing today.
+        handlers.append(
+            create_static_files_router(
+                path="/",
+                directories=[static_dir],
+                html_mode=True,
+            ),
+        )
+
+    return handlers
+
+
+app = Litestar(
+    route_handlers=build_route_handlers(config.STATIC_DIR),
     cors_config=cors_config,
 )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -18,6 +18,11 @@ dev = [
     "pytest-asyncio>=0.24.0",
     "httpx>=0.28.0",
     "pytest-cov>=7.1.0",
+    # Lint toolchain — pocket-dev has these pre-installed globally, but CI
+    # and other dev machines need them via uv sync. Pinned to current
+    # working versions; bump together when the toolchain shifts.
+    "ruff>=0.14.4",
+    "pyright>=1.1.405",
 ]
 
 [tool.pytest.ini_options]

--- a/backend/synclet/config.py
+++ b/backend/synclet/config.py
@@ -97,3 +97,10 @@ IGNORED_FILE = Path(
 # new secrets do not get fallbacks.
 SYNCTHING_URL = os.environ.get("SYNCTHING_URL")
 SYNCTHING_API_KEY = os.environ.get("SYNCTHING_API_KEY")
+
+# Production: the Vite-built frontend (vite build -> dist/) ships inside the
+# backend image and is served by the same Litestar process at /. Set via env
+# in the prod Dockerfile only. Unset in dev so the dev backend doesn't try to
+# serve a non-existent dir; dev frontend runs separately on :1313.
+_STATIC_DIR_ENV = os.environ.get("SYNCLET_STATIC_DIR")
+STATIC_DIR: Path | None = Path(_STATIC_DIR_ENV) if _STATIC_DIR_ENV else None

--- a/backend/tests/test_static_serve.py
+++ b/backend/tests/test_static_serve.py
@@ -1,0 +1,163 @@
+"""Tests for the optional static-file serving wired in main.py.
+
+The production Dockerfile sets SYNCLET_STATIC_DIR=/app/static so Litestar
+serves the bundled Vue SPA from the same port as the API. Dev leaves it
+unset; the dev frontend runs separately on :1313 against this backend.
+Both branches need pinning so a future refactor can't accidentally:
+  - poach /api/* requests with the static catchall (would return HTML
+    instead of JSON, silently breaking the frontend),
+  - skip the static handler when it should be registered, or
+  - register the static handler when it shouldn't be (dev).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from litestar import Litestar
+from litestar.testing import TestClient
+
+from main import build_route_handlers
+
+
+class TestBuildRouteHandlers:
+    """Unit tests for the route-handler list builder."""
+
+    def test_no_static_handler_when_static_dir_is_none(self):
+        """Dev: STATIC_DIR unset -> only API handlers, no static router."""
+        handlers = build_route_handlers(static_dir=None)
+        # All API handlers are decorated functions/coroutines, not Routers.
+        # The static router is a Router instance; its absence proves the
+        # dev branch is taken.
+        from litestar.router import Router
+
+        assert not any(isinstance(h, Router) for h in handlers)
+
+    def test_no_static_handler_when_dir_does_not_exist(self, tmp_path: Path):
+        """STATIC_DIR points somewhere that isn't a directory -> ignored.
+
+        Saves a startup crash if the env var points at a stale path on
+        production. Logged at info level by the builder.
+        """
+        bogus = tmp_path / "does-not-exist"
+        handlers = build_route_handlers(static_dir=bogus)
+        from litestar.router import Router
+
+        assert not any(isinstance(h, Router) for h in handlers)
+
+    def test_static_handler_appended_when_dir_exists(self, tmp_path: Path):
+        """Prod: STATIC_DIR points at a real dist/ -> static router added."""
+        (tmp_path / "index.html").write_text("<html>spa</html>")
+        handlers = build_route_handlers(static_dir=tmp_path)
+        from litestar.router import Router
+
+        routers = [h for h in handlers if isinstance(h, Router)]
+        assert len(routers) == 1, (
+            "exactly one static-files router expected when STATIC_DIR is set"
+        )
+
+    def test_static_router_is_last(self, tmp_path: Path):
+        """Static router must be appended AFTER the API handlers.
+
+        Litestar resolves overlapping paths by specificity, but if the static
+        router were registered first AND we ever switched to a less-specific
+        matcher, /api/* could end up being served as HTML. Position is a
+        cheap belt to the suspenders.
+        """
+        (tmp_path / "index.html").write_text("<html>spa</html>")
+        handlers = build_route_handlers(static_dir=tmp_path)
+        from litestar.router import Router
+
+        # Last handler in the list is the static router.
+        assert isinstance(handlers[-1], Router)
+
+
+class TestRouteSpecificity:
+    """Integration tests via TestClient: API > static, even with both registered.
+
+    These tests boot a fully-configured app with the static dir wired in,
+    then probe both surfaces. They pin the contract a UI regression test
+    can't pin: that the BACKEND keeps API routes JSON and static routes HTML.
+    """
+
+    @pytest.fixture
+    def app_with_static(self, tmp_path: Path) -> Litestar:
+        """Build an app the way main.py would, but with a tmp static dir."""
+        static_dir = tmp_path / "static"
+        static_dir.mkdir()
+        (static_dir / "index.html").write_text(
+            "<!doctype html><html><body><div id='app'></div></body></html>"
+        )
+        # Match the prod Dockerfile's index->404 clone so the SPA shell is
+        # the fallback for unknown paths.
+        (static_dir / "404.html").write_text(
+            "<!doctype html><html><body><div id='app'></div></body></html>"
+        )
+        # Stub the Plex/section_index caches so /api/state doesn't try to
+        # hit the network in the static-router-contract test.
+        return Litestar(route_handlers=build_route_handlers(static_dir))
+
+    def test_root_serves_spa_shell(self, app_with_static: Litestar):
+        with TestClient(app=app_with_static) as c:
+            r = c.get("/")
+            assert r.status_code == 200
+            assert "<div id='app'>" in r.text
+
+    def test_api_health_still_returns_text_not_html(self, app_with_static: Litestar):
+        """Even with the static catchall registered, /api/health is the
+        literal API route — must NOT be poached as a missing static file."""
+        with TestClient(app=app_with_static) as c:
+            r = c.get("/api/health")
+            assert r.status_code == 200
+            assert r.text == "OK"
+            # Crucial: not the SPA shell.
+            assert "<div id='app'>" not in r.text
+
+    def test_api_unknown_route_returns_json_404_not_html(
+        self, app_with_static: Litestar
+    ):
+        """Unmatched /api/* paths must return Litestar's JSON 404, not the
+        SPA shell. The frontend's `fetch()` wrapper relies on JSON error
+        bodies (api.ts:json()); returning HTML would crash the parse."""
+        with TestClient(app=app_with_static) as c:
+            r = c.get("/api/this-route-does-not-exist")
+            assert r.status_code == 404
+            assert r.headers["content-type"].startswith("application/json")
+            body = r.json()
+            assert body["status_code"] == 404
+
+    def test_unknown_non_api_path_serves_spa_fallback(self, app_with_static: Litestar):
+        """Non-/api/ paths fall back to 404.html (cloned from index.html in
+        the prod Dockerfile). Status is 404 (Litestar's html_mode keeps the
+        404 status); body is the SPA shell so Vue mounts and renders."""
+        with TestClient(app=app_with_static) as c:
+            r = c.get("/some/client/route/that-does-not-exist")
+            # Status stays 404 in html_mode; body is the SPA fallback.
+            assert r.status_code == 404
+            assert "<div id='app'>" in r.text
+
+
+class TestConfigStaticDir:
+    """Pin the config.STATIC_DIR env-parsing contract."""
+
+    def test_unset_env_means_none(self, monkeypatch):
+        monkeypatch.delenv("SYNCLET_STATIC_DIR", raising=False)
+        import importlib
+
+        from synclet import config
+
+        importlib.reload(config)
+        assert config.STATIC_DIR is None
+
+    def test_set_env_means_path(self, monkeypatch):
+        monkeypatch.setenv("SYNCLET_STATIC_DIR", "/some/static/dir")
+        import importlib
+
+        from synclet import config
+
+        importlib.reload(config)
+        assert Path("/some/static/dir") == config.STATIC_DIR
+        # Reset for other tests
+        monkeypatch.delenv("SYNCLET_STATIC_DIR", raising=False)
+        importlib.reload(config)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -292,6 +292,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -385,6 +394,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.409"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/4e/3aa27f74211522dba7e9cbc3e74de779c6d4b654c54e50a4840623be8014/pyright-1.1.409.tar.gz", hash = "sha256:986ee05beca9e077c165758ad123667c679e050059a2546aa02473930394bc93", size = 4430434, upload-time = "2026-04-23T11:02:03.799Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/6b/330d8ebae582b30c2959a1ef4c3bc344ebde48c2ff0c3f113c4710735e11/pyright-1.1.409-py3-none-any.whl", hash = "sha256:aa3ea228cab90c845c7a60d28db7a844c04315356392aa09fafcee98c8c22fb3", size = 6438161, upload-time = "2026-04-23T11:02:01.309Z" },
 ]
 
 [[package]]
@@ -483,6 +505,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/8a/8bce2894573e9dae6ff4d77fe34ad727d79b9e6238ad288c5638990d90f6/ruff-0.15.14.tar.gz", hash = "sha256:48e866b165be4a9bdbf310f7d3c9a07edef2fe8cd63ffeb4e00bb590506ebf9f", size = 4700910, upload-time = "2026-05-21T14:34:55.177Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/c8/74a92c6ff9fcfb4f1f947126d3ebee8389276e161ecc85de5bda7cda51bd/ruff-0.15.14-py3-none-linux_armv6l.whl", hash = "sha256:8dd2db9416e487c8d4b01fa7056bb02c4d05969d4f8d17a08c229c2f4ff3c108", size = 10739177, upload-time = "2026-05-21T14:34:37.332Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/254a35c20acc38a7223c9d2d594af12e794432464f2cdeb52af1dc4a892d/ruff-0.15.14-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:be4ff55af755bd71a00ab3dc6bd7ffc467bd76e0df6881e286c2e3d23e8fb43b", size = 11144969, upload-time = "2026-05-21T14:34:43.978Z" },
+    { url = "https://files.pythonhosted.org/packages/56/9e/d13e40f83b8d0a94430e6778ce1d94a43b38cf2efe63278bdd2b4c65abbf/ruff-0.15.14-py3-none-macosx_11_0_arm64.whl", hash = "sha256:48d5909d7d06276ce7dde6d32bfa4b0d4cb2651145cd8ee4b440722cbc77832f", size = 10478207, upload-time = "2026-05-21T14:34:48.378Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/f1/b15a7839fa4f332f8acec78e20564f26bb2d866e3d21710b877fd0263000/ruff-0.15.14-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca8cbfa94c4f90984a67561978602746d4cd27103568f745fa90eee3f0d4107d", size = 10818459, upload-time = "2026-05-21T14:34:22.318Z" },
+    { url = "https://files.pythonhosted.org/packages/45/33/53d651177f84f94b400a0e27f8824eeada3dddc9d5ee8aeb048f4352a520/ruff-0.15.14-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9a6bbc0333f1ab053423bcbf6226477d266ca7cec7738c4c8e3f55647803f3c4", size = 10541800, upload-time = "2026-05-21T14:34:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a6/868f87e0bf9786ed24b5d0d0ad8676b8a94fd1912f42cddf9cfc7857818a/ruff-0.15.14-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8a24a4f7605d7003a6674d4387651effd939dead3fddd0f36561eb77a9a2e542", size = 11342149, upload-time = "2026-05-21T14:34:46.365Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/8b/38cd5c19faffdcc05a408d2b78edccc69492ab9720eadb49ea15ef80d768/ruff-0.15.14-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:049b5326e53ed80978f2fc041a280603f69dd6b0c95464342a2bb4572d9d9e2f", size = 12212563, upload-time = "2026-05-21T14:34:28.579Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/4d/a3c5b874a556d5731e3e657aaf04311bb76f0a5c3ec220ed43051be6b64b/ruff-0.15.14-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4ed42e6696c8dfa5f06728e6441993901f548eb92d73bc472cb5a38d1395fbf", size = 11493299, upload-time = "2026-05-21T14:34:41.836Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c0/56472c251d09858a53e51efbd485b09e1995d8731668b76d52e5dd6ee0f1/ruff-0.15.14-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:715c543cf450c4888251f91c52f1942a800541d9bddd7ac060aa4e6b77ae7cba", size = 11455931, upload-time = "2026-05-21T14:34:57.276Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/4a/e2e7b4d8dbf233d4eace59c75bc3435fa6d8bd3bae82d351d4e4300c0fd1/ruff-0.15.14-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:72ebab6013ec887d439d8b7593737a0a4ffb06d45d209d4e4bf2e92813082d3f", size = 11400794, upload-time = "2026-05-21T14:34:39.773Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c7/83c0539fe34c3e09136204d1e75d6052492364e0b3cb05e9465423f567d7/ruff-0.15.14-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:49072d36abdbe97a8dd7f480afe9c675699c0c495d4c84076e2c1203c4550581", size = 10804759, upload-time = "2026-05-21T14:34:31.045Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a6/18f2bfc095a2ab4a78745644e428205532ce6653a5d0fa8501572891534d/ruff-0.15.14-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:958522aee105068640c2c2ceae08f413ae44d922f52a1374ac13d6a96032fc93", size = 10539517, upload-time = "2026-05-21T14:34:53.064Z" },
+    { url = "https://files.pythonhosted.org/packages/54/3a/5a8b3b69c654d4e4bf1d246ac5b49cbcdac6eaab6905925f8915f31e3b80/ruff-0.15.14-py3-none-musllinux_1_2_i686.whl", hash = "sha256:f3707da619a143a2e8830e2abab8224478d69ace2d28cb6c20543ae97c36bf61", size = 11065169, upload-time = "2026-05-21T14:34:24.484Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c5/8864e4e7925b836ea354b31d57641ec03830564e281a8b6f061f8c3e0ec1/ruff-0.15.14-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:bb01d645694e3ec0102105d07ef2d53703970407d59c04e59d3ba0b7a1d53553", size = 11560214, upload-time = "2026-05-21T14:34:50.975Z" },
+    { url = "https://files.pythonhosted.org/packages/36/38/012bf76752e1f89ed50b77b99532d90f3a3e287bc7918e1fc0948ac866ac/ruff-0.15.14-py3-none-win32.whl", hash = "sha256:6d0c1ad2a0ab718d39b6d8fd2217981ce4d625cd96a720095f798fb47d8b13e6", size = 10805548, upload-time = "2026-05-21T14:34:33.453Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/4ea2c170f10ad760fff2a5250beb18897719dc8b52b53a24cddbb9dd3f19/ruff-0.15.14-py3-none-win_amd64.whl", hash = "sha256:802342981e056db3851a7836e5b070f8f15f67d4a685ae2a6160939d364b2902", size = 11939523, upload-time = "2026-05-21T14:34:18.077Z" },
+    { url = "https://files.pythonhosted.org/packages/62/d5/bc97ff895ec35cf3925d4bd60f3b39d822f377a446906ec9bcc87405e59b/ruff-0.15.14-py3-none-win_arm64.whl", hash = "sha256:ff47b90a9ef6a40c9e2f3b479c1fb78531adf055b94c1eba0a7ba04b31951826", size = 11208607, upload-time = "2026-05-21T14:34:26.525Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -505,9 +552,11 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "httpx" },
+    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -521,9 +570,11 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "httpx", specifier = ">=0.28.0" },
+    { name = "pyright", specifier = ">=1.1.405" },
     { name = "pytest", specifier = ">=8.3.0" },
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "ruff", specifier = ">=0.14.4" },
 ]
 
 [[package]]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -57,22 +57,20 @@ services:
       - /mnt/user/data/media:/data/media:ro
       - /mnt/user/data/others/synced-media:/data/others/synced-media
       - /mnt/user/appdata/watchstate:/appdata/watchstate:ro
+    # Shared env contract — see synclet.env for the full set. The optional
+    # .env (gitignored) layers on top for secrets (Syncthing API key, a
+    # rotated Plex token). DO NOT mirror SYNCLET_* into `environment:`
+    # below — duplicated lines silently override synclet.env and the two
+    # sources of truth drift.
+    env_file:
+      - synclet.env
+      - path: .env
+        required: false
     environment:
-      - PYTHONUNBUFFERED=1
+      # Dev-only: backend container points uv at the out-of-tree venv so the
+      # bind-mounted /app source doesn't mask it. Prod sets this in the
+      # Dockerfile's ENV so it doesn't appear here.
       - UV_PROJECT_ENVIRONMENT=/opt/venv
-      - SYNCLET_MEDIA_ROOT=/data/media
-      - SYNCLET_SYNC_ROOT=/data/others/synced-media
-      - SYNCLET_WATCHSTATE_DB=/appdata/watchstate/users/jakelasky/watchstate_v02.db
-      - SYNCLET_PLEX_URL=${SYNCLET_PLEX_URL:-http://192.168.86.183:32400}
-      - SYNCLET_PLEX_TOKEN=${SYNCLET_PLEX_TOKEN:-7p79GK4xzWp6A_pyNJkw}
-      - SYNCLET_THUMB_CACHE=/app/data/.thumb-cache
-      # Syncthing integration (read-only, opt-in). NO committed defaults;
-      # both come from .env (gitignored). Absent values degrade the
-      # Syncthing UI panel to "not configured" without affecting the rest
-      # of Synclet. See .env.example for the template.
-      - SYNCTHING_URL=${SYNCTHING_URL:-}
-      - SYNCTHING_API_KEY=${SYNCTHING_API_KEY:-}
-      - LOG_LEVEL=INFO
     # host.docker.internal is not auto-resolved on Linux Docker the way it
     # is on Docker Desktop; the extra_hosts entry maps it to the Docker
     # bridge gateway so SYNCTHING_URL=http://host.docker.internal:8384

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,58 @@
+# Production compose. Single container: built Vue SPA + Litestar backend.
+# Used on Tower for the deployed Synclet instance. DO NOT use for dev —
+# docker-compose.dev.yml is the two-container hot-reload stack.
+#
+# Image is built and pushed by .github/workflows/publish.yml on push to
+# `dev` (-> :dev) or `main` (-> :latest). Pulled and redeployed by the
+# /ship skill. No `build:` directive here — production never rebuilds
+# from source on Tower.
+
+services:
+    synclet:
+        image: ghcr.io/jacob-lasky/synclet:${SYNCLET_TAG:-latest}
+        container_name: synclet
+        # The container itself listens on 1314 (Litestar serves both API and
+        # SPA from the same port). Map to host 1313 to keep the user-facing
+        # URL stable across dev and prod — dev's frontend was on host 1313.
+        ports:
+            - "1313:1314"
+        volumes:
+            # Host paths — evaluated on the Tower host. See dev compose for
+            # the path-translation rationale; the misc/ prefix matters for
+            # /coding but NOT for /data or /appdata.
+            - /mnt/user/data/media:/data/media:ro
+            - /mnt/user/data/others/synced-media:/data/others/synced-media
+            - /mnt/user/appdata/watchstate:/appdata/watchstate:ro
+            # Persistent app data: thumb cache, snapshot.json, ignored.json.
+            # Survives container recreate; lives outside the image.
+            - /mnt/user/appdata/synclet:/app/data
+        # Shared env contract lives in synclet.env (committed, no secrets).
+        # The optional .env (gitignored) layers on top for runtime secrets
+        # (Syncthing API key, rotated Plex token). DO NOT mirror SYNCLET_*
+        # into `environment:` below — duplicated lines silently override
+        # synclet.env and the two sources of truth drift.
+        env_file:
+            - synclet.env
+            - path: .env
+              required: false
+        # Same host.docker.internal mapping rationale as the dev compose:
+        # lets SYNCTHING_URL point at a Syncthing on the host without
+        # hardcoding a LAN IP.
+        extra_hosts:
+            - "host.docker.internal:host-gateway"
+        restart: unless-stopped
+        mem_limit: 2g
+        memswap_limit: 2g
+        # Health probe — UnRAID's UI surfaces this in the container list
+        # and /ship's Step 6 cross-checks it. Python is in PATH because the
+        # uv image base ships it; no curl needed in the runtime image.
+        healthcheck:
+            test:
+                - CMD
+                - python
+                - -c
+                - "import urllib.request; urllib.request.urlopen('http://localhost:1314/api/health', timeout=5)"
+            interval: 30s
+            timeout: 5s
+            retries: 3
+            start_period: 10s

--- a/synclet.env
+++ b/synclet.env
@@ -1,0 +1,37 @@
+# Shared env contract for both compose files. Container-level env vars
+# that are the SAME in dev and prod live here. Dev/prod-only vars stay
+# inline in the respective compose file's `environment:` block (e.g.
+# UV_PROJECT_ENVIRONMENT in dev, which is set by the prod Dockerfile's
+# ENV instead).
+#
+# DO NOT put secrets here. The two Plex defaults below are grandfathered
+# (legacy homelab config baked into the repo before the no-committed-
+# secrets rule landed). New secrets go in a gitignored .env that compose
+# layers on top via `env_file: [synclet.env, .env]`.
+#
+# DO NOT add inline `SYNCLET_*` env vars to either compose file's
+# `environment:` block — they'd silently override this file and the two
+# sources of truth would drift. Add new shared vars here; the override
+# pattern is "set in shell env or gitignored .env".
+
+PYTHONUNBUFFERED=1
+
+# Mounted from the host. /data/media is read-only source, /data/others/
+# synced-media is read-write (Syncthing watches it).
+SYNCLET_MEDIA_ROOT=/data/media
+SYNCLET_SYNC_ROOT=/data/others/synced-media
+
+# Watchstate DB, read-only. Filename is watchstate_v02.db (not user.db).
+SYNCLET_WATCHSTATE_DB=/appdata/watchstate/users/jakelasky/watchstate_v02.db
+
+# Plex defaults — grandfathered homelab config. Rotate by setting
+# SYNCLET_PLEX_TOKEN in the gitignored .env that compose layers on top.
+SYNCLET_PLEX_URL=http://192.168.86.183:32400
+SYNCLET_PLEX_TOKEN=7p79GK4xzWp6A_pyNJkw
+
+# In-container path. Mounted to /mnt/user/misc/coding/Synclet/data in dev
+# (bind, for editor visibility) and /mnt/user/appdata/synclet in prod
+# (persistent across container recreate).
+SYNCLET_THUMB_CACHE=/app/data/.thumb-cache
+
+LOG_LEVEL=INFO


### PR DESCRIPTION
Closes #30. First CI/CD pipeline for Synclet.

## Design decisions

Aligned with Jake on 2026-05-22 — full rationale in memory `project_synclet_deploy_shape.md`:

1. **dev + main branches** (deephive pattern). Push to `dev` → image tagged `:dev`. Push to `main` → image tagged `:latest`. Both also get a `:<short_sha>` tag.
2. **Single production image** — frontend is built statically (`pnpm build`) and copied into the backend container. Litestar serves the SPA from the same port (1314) as the API. One container, no CORS, no separate frontend service in production. Dev keeps its two-container hot-reload stack.
3. **No auto-redeploy** — explicitly not Watchtower, not an SSH webhook. CI publishes to GHCR; Jake redeploys via `/ship` when he wants.

## What this PR adds

### Build & runtime
- `Dockerfile` (new) — three-stage: frontend-builder (pnpm install + build + clone `index.html` → `404.html` for Litestar's SPA fallback), backend-builder (uv sync --frozen --no-dev), runtime (sets `SYNCLET_STATIC_DIR=/app/static`, runs `uvicorn main:app`). amd64-only, ~209 MB.
- `.dockerignore` (new) — keeps the build context lean (no node_modules, no venvs, no compose files, no .env, no Dockerfile.dev).

### Backend wiring
- `backend/synclet/config.py` — new `SYNCLET_STATIC_DIR` (Path | None). Unset in dev, set in prod.
- `backend/main.py` — extracted `build_route_handlers(static_dir)` as a pure, testable function. If static_dir is set + exists, appends Litestar's static-files router with `html_mode=True`. Router position is load-bearing (LAST so API specificity wins); pinned by tests.
- `backend/tests/test_static_serve.py` (new, 10 tests) — covers `build_route_handlers` branches, the route-specificity contract (`/api/health` stays text, `/api/*` 404 stays JSON, `/unknown` serves the SPA shell), and `config.STATIC_DIR` env parsing.

### Compose
- `docker-compose.prod.yml` (new) — single `synclet` service, image `ghcr.io/jacob-lasky/synclet:${SYNCLET_TAG:-latest}`, host 1313→1314, `restart: unless-stopped`, Python-based healthcheck on `/api/health` every 30s.
- `synclet.env` (new, committed) — single source of truth for the env vars both composes share. Plex defaults are grandfathered homelab config.
- `docker-compose.dev.yml` + `docker-compose.prod.yml` — both now `env_file: [synclet.env, .env (required: false)]`. Removed the ~10 duplicate `environment:` entries that would have drifted the first time a path changed in only one file.

### CI/CD
- `.github/workflows/ci.yml` — fires on PR + push to main/dev. Parallel `backend` and `frontend` jobs (uv + lint + pytest with 90% gate / pnpm + lint + build + vitest). `concurrency.group` cancels superseded runs.
- `.github/workflows/publish.yml` — fires via `workflow_run` AFTER ci succeeds on dev/main. Checks out `github.event.workflow_run.head_sha` to pin the build to the SHA that was tested. Pushes `ghcr.io/jacob-lasky/synclet` with both the channel tag (`:dev` / `:latest`) and the short SHA. amd64 only, GHA buildx cache.

### /ship skill
`~/.claude/commands/ship.md` rewritten to detect project from `git remote get-url origin` and route to either the deephive profile (existing, unchanged byte-for-byte) or a new Synclet profile. Synclet's profile uses `docker compose pull && up -d` instead of hand-rolled `docker run`. Calls out:
- First-deploy pre-flight: pre-create `/mnt/user/appdata/synclet` so Docker doesn't auto-tmpfs at the wrong path.
- "Fresh data" wipes go through `docker exec synclet rm` because container-written files are root-owned (same trap as deephive per-user files).

## Live verification

- `cd backend && ./lint.sh` → exit 0
- `cd backend && uv run pytest -q` → 245 passed, 92.38% coverage
- `cd frontend && pnpm lint && pnpm build && pnpm test` → all green, 46/46 tests
- `docker build -f Dockerfile -t synclet:probe . --memory=4g --memory-swap=4g` → exit 0
- Throwaway container probe:
  - `GET /api/health` → 200 `OK`
  - `GET /` → 200, HTML shell with `<div id="app">` + asset script tag
  - `GET /assets/index-*.js` → 200, 119775 bytes, `text/javascript`
  - `GET /some/client/route` → 404, body IS the SPA shell (Vue mounts and renders)
  - `GET /api/totally-not-a-route` → 404, `application/json`, `{"status_code":404,"detail":"Not Found"}`
  - `GET /api/syncthing/overview` → 200, `{"configured":false, "folders":[]}`
- `docker compose -f docker-compose.{dev,prod}.yml config` → both validate clean; env vars resolve through `env_file`.

## Visual artifact

DOM dump + asset-bundle headers + SPA-fallback assertion captured from the live production-image probe (above). Not a browser screenshot — pocket-dev has no headless browser — but the actual served HTML / JS content / Content-Type / Status was inspected end-to-end.

## First real deploy

When this lands on `main`, publish.yml will fire and publish `ghcr.io/jacob-lasky/synclet:latest`. First `/ship` to Synclet needs the pre-flight `mkdir + chown` per the skill body. After that, redeploys are `/ship` against any synclet-repo branch.